### PR TITLE
feat: implement vision tools (Phase 1.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ npx tsc --noEmit
 
 ## Project Structure
 
-```
+```text
 src/
 ├── index.ts           # Entry point, server setup, tool registration
 ├── utils/
@@ -90,7 +90,7 @@ type Keycode = string | number;
 - **Variables/functions:** camelCase (`execAdb`, `resolveSerial`)
 - **Interfaces/types:** PascalCase (`DeviceInfo`, `ExecResult`)
 - **Constants:** UPPER_SNAKE_CASE for true constants (`KEYCODE_MAP`, `DEFAULT_TIMEOUT`)
-- **Files:** lowercase with underscores (`device.ts`, `adb.ts`)
+- **Files:** lowercase filenames (`device.ts`, `adb.ts`)
 - **Tool names:** snake_case (`device_list`, `screen_on`)
 
 ### Function Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,200 @@
+# AGENTS.md
+
+Guidelines for AI coding agents working on scrcpy-mcp.
+
+## Project Overview
+
+scrcpy-mcp is a Model Context Protocol (MCP) server that provides AI agents with vision and control over Android devices via ADB and scrcpy. It exposes tools for device management, input, screenshots, and more.
+
+## Build/Lint/Test Commands
+
+```bash
+# Build the project
+npm run build
+
+# Development mode (run directly with tsx)
+npm run dev
+
+# Run the built server
+npm start
+
+# Run MCP Inspector for testing
+npm run inspect
+
+# Lint check
+npm run lint
+
+# Lint with auto-fix
+npm run lint:fix
+
+# Type check (use tsc directly)
+npx tsc --noEmit
+```
+
+**Note:** There is no test framework configured yet. When tests are added, use Vitest.
+
+## Project Structure
+
+```
+src/
+├── index.ts           # Entry point, server setup, tool registration
+├── utils/
+│   └── adb.ts         # ADB utility functions (exec, device detection, etc.)
+└── tools/
+    ├── device.ts      # Device management tools
+    ├── input.ts       # Touch/keyboard input tools
+    └── vision.ts      # Screenshot and recording tools
+```
+
+## Code Style Guidelines
+
+### Imports
+
+- Use ESM imports with `.js` extension for local modules (required by Node16 moduleResolution)
+- Group imports: external packages first, then local modules
+- Import from specific SDK paths: `@modelcontextprotocol/sdk/server/mcp.js`
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { execAdbShell, resolveSerial } from "../utils/adb.js";
+```
+
+### Formatting
+
+- No semicolons at end of statements
+- 2-space indentation
+- Max line length: ~100 characters
+- Trailing commas in multiline arrays/objects
+
+### Types
+
+- Use TypeScript strict mode
+- Define interfaces for complex objects
+- Use `type` for unions and simple aliases
+- Prefer `interface` for object shapes
+- Use `const` for constant objects that won't change
+
+```typescript
+interface DeviceInfo {
+  serial: string;
+  state: "device" | "unauthorized" | "offline" | string;
+  model?: string;
+}
+
+type Keycode = string | number;
+```
+
+### Naming Conventions
+
+- **Variables/functions:** camelCase (`execAdb`, `resolveSerial`)
+- **Interfaces/types:** PascalCase (`DeviceInfo`, `ExecResult`)
+- **Constants:** UPPER_SNAKE_CASE for true constants (`KEYCODE_MAP`, `DEFAULT_TIMEOUT`)
+- **Files:** lowercase with underscores (`device.ts`, `adb.ts`)
+- **Tool names:** snake_case (`device_list`, `screen_on`)
+
+### Function Style
+
+- Prefer `async/await` over raw promises
+- Arrow functions for callbacks and short utilities
+- Named function declarations for exported utilities
+- Use early returns to reduce nesting
+
+```typescript
+export async function resolveSerial(serial?: string): Promise<string> {
+  if (serial) return serial;
+  
+  const envSerial = process.env.ANDROID_SERIAL;
+  if (envSerial) return envSerial;
+  
+  // ... rest of logic
+}
+```
+
+### Error Handling
+
+- Throw `Error` objects with descriptive messages
+- Include context in error messages (command, device serial, etc.)
+- Use `{ cause }` option to preserve original error chain
+
+```typescript
+throw new Error(
+  `ADB command failed: ${ADB_PATH} ${args.join(" ")}\n${err.stderr || err.message}`,
+  { cause: error }
+);
+```
+
+- Return error info in tool responses rather than throwing when the error is user-facing
+
+### MCP Tool Registration Pattern
+
+```typescript
+server.tool(
+  "tool_name",
+  "Description of what the tool does",
+  {
+    param: z.string().optional().describe("Parameter description"),
+    required: z.number().describe("Required parameter"),
+  },
+  async ({ param, required }) => {
+    const result = await doWork(param, required);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result) }],
+    };
+  }
+);
+```
+
+### Zod Schema Patterns
+
+- Use `.optional()` for optional parameters
+- Use `.describe()` for all parameters (used for tool documentation)
+- Use `.default()` for parameters with defaults
+- Use `.int().nonnegative()` for coordinates
+
+```typescript
+{
+  x: z.number().int().nonnegative().describe("X coordinate"),
+  serial: z.string().optional().describe("Device serial number"),
+  duration: z.number().int().positive().optional().default(300),
+}
+```
+
+### Environment Variables
+
+- `ADB_PATH`: Custom ADB binary path (default: "adb")
+- `ANDROID_SERIAL`: Default device serial
+
+### Comments
+
+- Avoid comments unless code is genuinely complex
+- Prefer self-documenting code with clear names
+- Use `console.error()` for server-side logging (goes to stderr, not MCP protocol)
+
+## Key Implementation Notes
+
+### ADB Utilities (`src/utils/adb.ts`)
+
+- `execAdb()`: Run adb command, returns `{ stdout, stderr }`
+- `execAdbRaw()`: Run adb command, returns `Buffer` (for binary data)
+- `execAdbShell()`: Run `adb -s <serial> shell <command>`
+- `resolveSerial()`: Auto-detect device or validate provided serial
+- `getDevices()`: Parse `adb devices -l` output
+
+### Tool Response Format
+
+All tools return:
+```typescript
+{
+  content: [
+    { type: "text", text: "..." } |
+    { type: "image", data: base64, mimeType: "image/png" }
+  ]
+}
+```
+
+## Before Committing
+
+1. Run `npm run lint` and fix any issues
+2. Run `npm run build` to ensure it compiles
+3. Test with `npm run inspect` if making tool changes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,13 +54,13 @@ Get a working MCP server with ADB-based functionality first. This provides immed
 
 ### 1.6 Input Tools - ADB Fallback (`src/tools/input.ts`)
 
-- [ ] 1.6.1 Implement `tap` - ADB `input tap x y`
-- [ ] 1.6.2 Implement `swipe` - ADB `input swipe x1 y1 x2 y2 duration`
-- [ ] 1.6.3 Implement `long_press` - ADB `input swipe x y x y duration`
-- [ ] 1.6.4 Implement `drag_drop` - ADB `input draganddrop`
-- [ ] 1.6.5 Implement `input_text` - ADB `input text` with shell escaping
-- [ ] 1.6.6 Implement `key_event` - ADB `input keyevent` with keycode map
-- [ ] 1.6.7 Implement `scroll` - ADB `input swipe` with small delta (fallback only)
+- [x] 1.6.1 Implement `tap` - ADB `input tap x y`
+- [x] 1.6.2 Implement `swipe` - ADB `input swipe x1 y1 x2 y2 duration`
+- [x] 1.6.3 Implement `long_press` - ADB `input swipe x y x y duration`
+- [x] 1.6.4 Implement `drag_drop` - ADB `input draganddrop`
+- [x] 1.6.5 Implement `input_text` - ADB `input text` with shell escaping
+- [x] 1.6.6 Implement `key_event` - ADB `input keyevent` with keycode map
+- [x] 1.6.7 Implement `scroll` - ADB `input swipe` with small delta (fallback only)
 
 ### 1.7 Build and Test
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,9 +48,9 @@ Get a working MCP server with ADB-based functionality first. This provides immed
 
 ### 1.5 Vision Tools - ADB Fallback (`src/tools/vision.ts`)
 
-- [ ] 1.5.1 Implement `screenshot` - ADB `exec-out screencap -p`, return base64 image
-- [ ] 1.5.2 Implement `screen_record_start` - spawn `screenrecord` in background
-- [ ] 1.5.3 Implement `screen_record_stop` - kill screenrecord process
+- [x] 1.5.1 Implement `screenshot` - ADB `exec-out screencap -p`, return base64 image
+- [x] 1.5.2 Implement `screen_record_start` - spawn `screenrecord` in background
+- [x] 1.5.3 Implement `screen_record_stop` - kill screenrecord process
 
 ### 1.6 Input Tools - ADB Fallback (`src/tools/input.ts`)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerDeviceTools } from "./tools/device.js";
 import { registerVisionTools } from "./tools/vision.js";
+import { registerInputTools } from "./tools/input.js";
 
 const server = new McpServer({
   name: "scrcpy-mcp",
@@ -12,6 +13,7 @@ const server = new McpServer({
 
 registerDeviceTools(server);
 registerVisionTools(server);
+registerInputTools(server);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerDeviceTools } from "./tools/device.js";
+import { registerVisionTools } from "./tools/vision.js";
 
 const server = new McpServer({
   name: "scrcpy-mcp",
@@ -10,6 +11,7 @@ const server = new McpServer({
 });
 
 registerDeviceTools(server);
+registerVisionTools(server);
 
 async function main() {
   const transport = new StdioServerTransport();

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -1,0 +1,207 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { execAdbShell, resolveSerial } from "../utils/adb.js";
+
+const KEYCODE_MAP: Record<string, number> = {
+  HOME: 3,
+  BACK: 4,
+  CALL: 5,
+  END_CALL: 6,
+  VOLUME_UP: 24,
+  VOLUME_DOWN: 25,
+  POWER: 26,
+  CAMERA: 27,
+  ENTER: 66,
+  DELETE: 67,
+  TAB: 61,
+  MENU: 82,
+  APP_SWITCH: 187,
+  DPAD_UP: 19,
+  DPAD_DOWN: 20,
+  DPAD_LEFT: 21,
+  DPAD_RIGHT: 22,
+  DPAD_CENTER: 23,
+  WAKEUP: 224,
+  SLEEP: 223,
+  MEDIA_PLAY_PAUSE: 85,
+  MEDIA_NEXT: 87,
+  MEDIA_PREVIOUS: 88,
+  BRIGHTNESS_UP: 221,
+  BRIGHTNESS_DOWN: 220,
+  NOTIFICATION: 83,
+};
+
+function escapeTextForShell(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'")
+    .replace(/ /g, "%s")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\{/g, "\\{")
+    .replace(/\}/g, "\\}")
+    .replace(/\|/g, "\\|")
+    .replace(/;/g, "\\;")
+    .replace(/</g, "\\<")
+    .replace(/>/g, "\\>")
+    .replace(/&/g, "\\&")
+    .replace(/\*/g, "\\*")
+    .replace(/\?/g, "\\?")
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/!/g, "\\!");
+}
+
+function resolveKeycode(keycode: string | number): number {
+  if (typeof keycode === "number") {
+    return keycode;
+  }
+  const upperKey = keycode.toUpperCase();
+  if (KEYCODE_MAP[upperKey] !== undefined) {
+    return KEYCODE_MAP[upperKey];
+  }
+  const parsed = parseInt(keycode, 10);
+  if (isNaN(parsed)) {
+    throw new Error(`Unknown keycode: ${keycode}`);
+  }
+  return parsed;
+}
+
+export function registerInputTools(server: McpServer) {
+  server.tool(
+    "tap",
+    "Tap at the specified screen coordinates",
+    {
+      x: z.number().int().nonnegative().describe("X coordinate"),
+      y: z.number().int().nonnegative().describe("Y coordinate"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ x, y, serial }) => {
+      const s = await resolveSerial(serial);
+      await execAdbShell(s, `input tap ${x} ${y}`);
+      return {
+        content: [{ type: "text", text: `Tapped at (${x}, ${y})` }],
+      };
+    }
+  );
+
+  server.tool(
+    "swipe",
+    "Perform a swipe gesture from one point to another",
+    {
+      x1: z.number().int().nonnegative().describe("Start X coordinate"),
+      y1: z.number().int().nonnegative().describe("Start Y coordinate"),
+      x2: z.number().int().nonnegative().describe("End X coordinate"),
+      y2: z.number().int().nonnegative().describe("End Y coordinate"),
+      duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ x1, y1, x2, y2, duration, serial }) => {
+      const s = await resolveSerial(serial);
+      await execAdbShell(s, `input swipe ${x1} ${y1} ${x2} ${y2} ${duration}`);
+      return {
+        content: [{ type: "text", text: `Swiped from (${x1}, ${y1}) to (${x2}, ${y2}) in ${duration}ms` }],
+      };
+    }
+  );
+
+  server.tool(
+    "long_press",
+    "Perform a long press at the specified coordinates",
+    {
+      x: z.number().int().nonnegative().describe("X coordinate"),
+      y: z.number().int().nonnegative().describe("Y coordinate"),
+      duration: z.number().int().positive().optional().default(500).describe("Duration in milliseconds"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ x, y, duration, serial }) => {
+      const s = await resolveSerial(serial);
+      await execAdbShell(s, `input swipe ${x} ${y} ${x} ${y} ${duration}`);
+      return {
+        content: [{ type: "text", text: `Long pressed at (${x}, ${y}) for ${duration}ms` }],
+      };
+    }
+  );
+
+  server.tool(
+    "drag_drop",
+    "Perform a drag and drop gesture from one point to another",
+    {
+      startX: z.number().int().nonnegative().describe("Start X coordinate"),
+      startY: z.number().int().nonnegative().describe("Start Y coordinate"),
+      endX: z.number().int().nonnegative().describe("End X coordinate"),
+      endY: z.number().int().nonnegative().describe("End Y coordinate"),
+      duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ startX, startY, endX, endY, duration, serial }) => {
+      const s = await resolveSerial(serial);
+      await execAdbShell(s, `input draganddrop ${startX} ${startY} ${endX} ${endY} ${duration}`);
+      return {
+        content: [{ type: "text", text: `Dragged from (${startX}, ${startY}) to (${endX}, ${endY}) in ${duration}ms` }],
+      };
+    }
+  );
+
+  server.tool(
+    "input_text",
+    "Type text into the currently focused input field",
+    {
+      text: z.string().describe("Text to type"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ text, serial }) => {
+      const s = await resolveSerial(serial);
+      const escaped = escapeTextForShell(text);
+      await execAdbShell(s, `input text "${escaped}"`);
+      return {
+        content: [{ type: "text", text: `Typed: "${text}"` }],
+      };
+    }
+  );
+
+  server.tool(
+    "key_event",
+    "Send a key event to the device. Supports keycodes like HOME, BACK, ENTER, VOLUME_UP, etc.",
+    {
+      keycode: z.union([z.string(), z.number()]).describe("Keycode name (e.g., 'HOME', 'BACK') or numeric value"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ keycode, serial }) => {
+      const s = await resolveSerial(serial);
+      const code = resolveKeycode(keycode);
+      await execAdbShell(s, `input keyevent ${code}`);
+      return {
+        content: [{ type: "text", text: `Sent key event: ${keycode} (${code})` }],
+      };
+    }
+  );
+
+  server.tool(
+    "scroll",
+    "Scroll at the specified position. dx and dy are scroll amounts (-1 to 1 range approximated for ADB).",
+    {
+      x: z.number().int().nonnegative().describe("X coordinate to scroll at"),
+      y: z.number().int().nonnegative().describe("Y coordinate to scroll at"),
+      dx: z.number().describe("Horizontal scroll amount (negative=left, positive=right)"),
+      dy: z.number().describe("Vertical scroll amount (negative=up, positive=down)"),
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ x, y, dx, dy, serial }) => {
+      const s = await resolveSerial(serial);
+      const duration = 300;
+      const distance = 100;
+      
+      const endX = Math.round(x + dx * distance);
+      const endY = Math.round(y + dy * distance);
+      
+      await execAdbShell(s, `input swipe ${x} ${y} ${endX} ${endY} ${duration}`);
+      return {
+        content: [{ type: "text", text: `Scrolled at (${x}, ${y}) with delta (${dx}, ${dy})` }],
+      };
+    }
+  );
+}

--- a/src/tools/vision.ts
+++ b/src/tools/vision.ts
@@ -1,0 +1,147 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { execAdb, execAdbRaw, resolveSerial } from "../utils/adb.js";
+import { spawn, ChildProcess } from "child_process";
+
+const recordingProcesses: Map<string, ChildProcess> = new Map();
+
+export function registerVisionTools(server: McpServer) {
+  server.tool(
+    "screenshot",
+    "Take a screenshot of the Android device screen. Returns the image as base64.",
+    {
+      serial: z.string().optional().describe("Device serial number"),
+    },
+    async ({ serial }) => {
+      const s = await resolveSerial(serial);
+      const pngBuffer = await execAdbRaw(["-s", s, "exec-out", "screencap", "-p"]);
+      
+      return {
+        content: [
+          {
+            type: "image" as const,
+            data: pngBuffer.toString("base64"),
+            mimeType: "image/png",
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    "screen_record_start",
+    "Start recording the screen. Recording continues until screen_record_stop is called.",
+    {
+      serial: z.string().optional().describe("Device serial number"),
+      remotePath: z
+        .string()
+        .optional()
+        .default("/sdcard/scrcpy-mcp-recording.mp4")
+        .describe("Path on device to save recording"),
+      duration: z
+        .number()
+        .optional()
+        .describe("Max recording duration in seconds (optional, device limit usually 180s)"),
+    },
+    async ({ serial, remotePath, duration }) => {
+      const s = await resolveSerial(serial);
+      
+      if (recordingProcesses.has(s)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Recording already in progress for device ${s}`,
+            },
+          ],
+        };
+      }
+
+      const args = ["-s", s, "shell", "screenrecord", remotePath];
+      if (duration) {
+        args.push("--time-limit", String(duration));
+      }
+
+      const proc = spawn("adb", args);
+      recordingProcesses.set(s, proc);
+
+      proc.on("close", () => {
+        recordingProcesses.delete(s);
+      });
+
+      proc.stderr?.on("data", (data) => {
+        console.error(`[screenrecord ${s}] ${data}`);
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Recording started on device ${s}. Will save to ${remotePath}`,
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    "screen_record_stop",
+    "Stop screen recording and optionally pull the file to the host.",
+    {
+      serial: z.string().optional().describe("Device serial number"),
+      pullToHost: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Pull the recording to the host machine"),
+      localPath: z
+        .string()
+        .optional()
+        .describe("Local path to save recording (only if pullToHost is true)"),
+    },
+    async ({ serial, pullToHost, localPath }) => {
+      const s = await resolveSerial(serial);
+      const remotePath = "/sdcard/scrcpy-mcp-recording.mp4";
+      
+      const proc = recordingProcesses.get(s);
+      if (!proc) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No recording in progress for device ${s}`,
+            },
+          ],
+        };
+      }
+
+      proc.kill("SIGINT");
+      recordingProcesses.delete(s);
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      if (pullToHost) {
+        const targetPath = localPath || `./recording-${s}.mp4`;
+        await execAdb(["-s", s, "pull", remotePath, targetPath]);
+        
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Recording stopped and saved to ${targetPath}`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Recording stopped. File saved on device at ${remotePath}`,
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/utils/adb.ts
+++ b/src/utils/adb.ts
@@ -3,7 +3,7 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
-const ADB_PATH = process.env.ADB_PATH || "adb";
+export const ADB_PATH = process.env.ADB_PATH || "adb";
 const DEFAULT_TIMEOUT = 30000;
 
 export interface ExecResult {


### PR DESCRIPTION
- Add screenshot tool (returns base64 PNG image)
- Add screen_record_start for background recording
- Add screen_record_stop with optional file pull
- Register vision tools in entry point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vision tools: device screenshot and screen recording (start/stop), per-device recording management, and optional download of recordings.
  * Input controls: tap, swipe, long-press, drag-and-drop, text input, key events, and scrolling for device interaction.

* **Documentation**
  * ROADMAP updated: Vision and all Input tool tasks marked completed.
  * New contributor guidelines added covering project structure, coding standards, and tool integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->