### PR TITLE
refactor: migrate from deprecated server.tool() to server.registerTool()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,12 +129,14 @@ throw new Error(
 ### MCP Tool Registration Pattern
 
 ```typescript
-server.tool(
+server.registerTool(
   "tool_name",
-  "Description of what the tool does",
   {
-    param: z.string().optional().describe("Parameter description"),
-    required: z.number().describe("Required parameter"),
+    description: "Description of what the tool does",
+    inputSchema: {
+      param: z.string().optional().describe("Parameter description"),
+      required: z.number().describe("Required parameter"),
+    },
   },
   async ({ param, required }) => {
     const result = await doWork(param, required);

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -110,6 +110,7 @@ export function registerDeviceTools(server: McpServer) {
       inputSchema: {
         port: z
           .number()
+          .int()
           .optional()
           .default(5555)
           .describe("TCP port for ADB connection (default: 5555)"),

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -181,7 +181,7 @@ export function registerDeviceTools(server: McpServer) {
       } catch (error) {
         const err = error as Error;
         return {
-          content: [{ type: "text", text: `Failed to disconnect from ${address}: ${err.message}` }],
+          content: [{ type: "text", text: JSON.stringify({ error: true, message: `Failed to disconnect from ${address}: ${err.message}` }) }],
         };
       }
     }

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -173,10 +173,17 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ address }) => {
-      await execAdb(["disconnect", address]);
-      return {
-        content: [{ type: "text", text: `Disconnected from ${address}` }],
-      };
+      try {
+        await execAdb(["disconnect", address]);
+        return {
+          content: [{ type: "text", text: `Disconnected from ${address}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [{ type: "text", text: `Failed to disconnect from ${address}: ${err.message}` }],
+        };
+      }
     }
   );
 }

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -10,10 +10,12 @@ import {
 } from "../utils/adb.js";
 
 export function registerDeviceTools(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "device_list",
-    "List all connected Android devices with their serial numbers, state, and model",
-    {},
+    {
+      description: "List all connected Android devices with their serial numbers, state, and model",
+      inputSchema: {},
+    },
     async () => {
       const devices = await getDevices();
       return {
@@ -22,16 +24,16 @@ export function registerDeviceTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "device_info",
-    "Get detailed info about a device: model, Android version, screen size, SDK level, battery level",
     {
-      serial: z
-        .string()
-        .optional()
-        .describe(
-          "Device serial number. If omitted, uses the only connected device."
-        ),
+      description: "Get detailed info about a device: model, Android version, screen size, SDK level, battery level",
+      inputSchema: {
+        serial: z
+          .string()
+          .optional()
+          .describe("Device serial number. If omitted, uses the only connected device."),
+      },
     },
     async ({ serial }) => {
       const s = await resolveSerial(serial);
@@ -67,11 +69,13 @@ export function registerDeviceTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "screen_on",
-    "Wake the device screen (turn screen on)",
     {
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Wake the device screen (turn screen on)",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ serial }) => {
       const s = await resolveSerial(serial);
@@ -82,11 +86,13 @@ export function registerDeviceTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "screen_off",
-    "Turn the device screen off",
     {
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Turn the device screen off",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ serial }) => {
       const s = await resolveSerial(serial);
@@ -97,16 +103,18 @@ export function registerDeviceTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "connect_wifi",
-    "Enable WiFi ADB and connect to the device wirelessly. Returns the connection address.",
     {
-      port: z
-        .number()
-        .optional()
-        .default(5555)
-        .describe("TCP port for ADB connection (default: 5555)"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Enable WiFi ADB and connect to the device wirelessly. Returns the connection address.",
+      inputSchema: {
+        port: z
+          .number()
+          .optional()
+          .default(5555)
+          .describe("TCP port for ADB connection (default: 5555)"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ port, serial }) => {
       const s = await resolveSerial(serial);
@@ -136,11 +144,13 @@ export function registerDeviceTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "disconnect_wifi",
-    "Disconnect from a wireless ADB device",
     {
-      address: z.string().describe("Device address (e.g., 192.168.1.100:5555)"),
+      description: "Disconnect from a wireless ADB device",
+      inputSchema: {
+        address: z.string().describe("Device address (e.g., 192.168.1.100:5555)"),
+      },
     },
     async ({ address }) => {
       await execAdb(["disconnect", address]);

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -36,36 +36,48 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
-      const s = await resolveSerial(serial);
-      const [model, brand, manufacturer, version, sdk, screenSize, battery] =
-        await Promise.all([
-          getDeviceProperty(s, "ro.product.model"),
-          getDeviceProperty(s, "ro.product.brand"),
-          getDeviceProperty(s, "ro.product.manufacturer"),
-          getDeviceProperty(s, "ro.build.version.release"),
-          getDeviceProperty(s, "ro.build.version.sdk"),
-          getScreenSize(s),
-          execAdbShell(s, "dumpsys battery"),
-        ]);
+      try {
+        const s = await resolveSerial(serial);
+        const [model, brand, manufacturer, version, sdk, screenSize, battery] =
+          await Promise.all([
+            getDeviceProperty(s, "ro.product.model"),
+            getDeviceProperty(s, "ro.product.brand"),
+            getDeviceProperty(s, "ro.product.manufacturer"),
+            getDeviceProperty(s, "ro.build.version.release"),
+            getDeviceProperty(s, "ro.build.version.sdk"),
+            getScreenSize(s),
+            execAdbShell(s, "dumpsys battery"),
+          ]);
 
-      const batteryMatch = battery.match(/level:\s*(\d+)/);
-      const batteryLevel = batteryMatch ? parseInt(batteryMatch[1], 10) : null;
+        const batteryMatch = battery.match(/level:\s*(\d+)/);
+        const batteryLevel = batteryMatch ? parseInt(batteryMatch[1], 10) : null;
 
-      const info = {
-        serial: s,
-        model: model || null,
-        brand: brand || null,
-        manufacturer: manufacturer || null,
-        androidVersion: version || null,
-        sdkLevel: sdk ? parseInt(sdk, 10) : null,
-        screenWidth: screenSize.width,
-        screenHeight: screenSize.height,
-        batteryLevel,
-      };
+        const info = {
+          serial: s,
+          model: model || null,
+          brand: brand || null,
+          manufacturer: manufacturer || null,
+          androidVersion: version || null,
+          sdkLevel: sdk ? parseInt(sdk, 10) : null,
+          screenWidth: screenSize.width,
+          screenHeight: screenSize.height,
+          batteryLevel,
+        };
 
-      return {
-        content: [{ type: "text", text: JSON.stringify(info, null, 2) }],
-      };
+        return {
+          content: [{ type: "text", text: JSON.stringify(info, null, 2) }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to get device info: ${err.message}` }),
+            },
+          ],
+        };
+      }
     }
   );
 
@@ -78,11 +90,23 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
-      const s = await resolveSerial(serial);
-      await execAdbShell(s, "input keyevent KEYCODE_WAKEUP");
-      return {
-        content: [{ type: "text", text: `Screen turned on for device ${s}` }],
-      };
+      try {
+        const s = await resolveSerial(serial);
+        await execAdbShell(s, "input keyevent KEYCODE_WAKEUP");
+        return {
+          content: [{ type: "text", text: `Screen turned on for device ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to turn screen on: ${err.message}` }),
+            },
+          ],
+        };
+      }
     }
   );
 
@@ -95,11 +119,23 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
-      const s = await resolveSerial(serial);
-      await execAdbShell(s, "input keyevent KEYCODE_SLEEP");
-      return {
-        content: [{ type: "text", text: `Screen turned off for device ${s}` }],
-      };
+      try {
+        const s = await resolveSerial(serial);
+        await execAdbShell(s, "input keyevent KEYCODE_SLEEP");
+        return {
+          content: [{ type: "text", text: `Screen turned off for device ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to turn screen off: ${err.message}` }),
+            },
+          ],
+        };
+      }
     }
   );
 

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -71,13 +71,15 @@ function resolveKeycode(keycode: string | number): number {
 }
 
 export function registerInputTools(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "tap",
-    "Tap at the specified screen coordinates",
     {
-      x: z.number().int().nonnegative().describe("X coordinate"),
-      y: z.number().int().nonnegative().describe("Y coordinate"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Tap at the specified screen coordinates",
+      inputSchema: {
+        x: z.number().int().nonnegative().describe("X coordinate"),
+        y: z.number().int().nonnegative().describe("Y coordinate"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ x, y, serial }) => {
       const s = await resolveSerial(serial);
@@ -88,16 +90,18 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "swipe",
-    "Perform a swipe gesture from one point to another",
     {
-      x1: z.number().int().nonnegative().describe("Start X coordinate"),
-      y1: z.number().int().nonnegative().describe("Start Y coordinate"),
-      x2: z.number().int().nonnegative().describe("End X coordinate"),
-      y2: z.number().int().nonnegative().describe("End Y coordinate"),
-      duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Perform a swipe gesture from one point to another",
+      inputSchema: {
+        x1: z.number().int().nonnegative().describe("Start X coordinate"),
+        y1: z.number().int().nonnegative().describe("Start Y coordinate"),
+        x2: z.number().int().nonnegative().describe("End X coordinate"),
+        y2: z.number().int().nonnegative().describe("End Y coordinate"),
+        duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ x1, y1, x2, y2, duration, serial }) => {
       const s = await resolveSerial(serial);
@@ -108,14 +112,16 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "long_press",
-    "Perform a long press at the specified coordinates",
     {
-      x: z.number().int().nonnegative().describe("X coordinate"),
-      y: z.number().int().nonnegative().describe("Y coordinate"),
-      duration: z.number().int().positive().optional().default(500).describe("Duration in milliseconds"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Perform a long press at the specified coordinates",
+      inputSchema: {
+        x: z.number().int().nonnegative().describe("X coordinate"),
+        y: z.number().int().nonnegative().describe("Y coordinate"),
+        duration: z.number().int().positive().optional().default(500).describe("Duration in milliseconds"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ x, y, duration, serial }) => {
       const s = await resolveSerial(serial);
@@ -126,16 +132,18 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "drag_drop",
-    "Perform a drag and drop gesture from one point to another. Uses input draganddrop on Android 8.0+ (API 26), falls back to swipe on older versions.",
     {
-      startX: z.number().int().nonnegative().describe("Start X coordinate"),
-      startY: z.number().int().nonnegative().describe("Start Y coordinate"),
-      endX: z.number().int().nonnegative().describe("End X coordinate"),
-      endY: z.number().int().nonnegative().describe("End Y coordinate"),
-      duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Perform a drag and drop gesture from one point to another. Uses input draganddrop on Android 8.0+ (API 26), falls back to swipe on older versions.",
+      inputSchema: {
+        startX: z.number().int().nonnegative().describe("Start X coordinate"),
+        startY: z.number().int().nonnegative().describe("Start Y coordinate"),
+        endX: z.number().int().nonnegative().describe("End X coordinate"),
+        endY: z.number().int().nonnegative().describe("End Y coordinate"),
+        duration: z.number().int().positive().optional().default(300).describe("Duration in milliseconds"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ startX, startY, endX, endY, duration, serial }) => {
       const s = await resolveSerial(serial);
@@ -158,12 +166,14 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "input_text",
-    "Type text into the currently focused input field",
     {
-      text: z.string().describe("Text to type"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Type text into the currently focused input field",
+      inputSchema: {
+        text: z.string().describe("Text to type"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ text, serial }) => {
       const s = await resolveSerial(serial);
@@ -175,12 +185,14 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "key_event",
-    "Send a key event to the device. Supports keycodes like HOME, BACK, ENTER, VOLUME_UP, etc.",
     {
-      keycode: z.union([z.string(), z.number()]).describe("Keycode name (e.g., 'HOME', 'BACK') or numeric value"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Send a key event to the device. Supports keycodes like HOME, BACK, ENTER, VOLUME_UP, etc.",
+      inputSchema: {
+        keycode: z.union([z.string(), z.number()]).describe("Keycode name (e.g., 'HOME', 'BACK') or numeric value"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ keycode, serial }) => {
       const s = await resolveSerial(serial);
@@ -192,15 +204,17 @@ export function registerInputTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "scroll",
-    "Scroll at the specified position. dx and dy are scroll amounts (-1 to 1 range approximated for ADB).",
     {
-      x: z.number().int().nonnegative().describe("X coordinate to scroll at"),
-      y: z.number().int().nonnegative().describe("Y coordinate to scroll at"),
-      dx: z.number().describe("Horizontal scroll amount (negative=left, positive=right)"),
-      dy: z.number().describe("Vertical scroll amount (negative=up, positive=down)"),
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Scroll at the specified position. dx and dy are scroll amounts (-1 to 1 range approximated for ADB).",
+      inputSchema: {
+        x: z.number().int().nonnegative().describe("X coordinate to scroll at"),
+        y: z.number().int().nonnegative().describe("Y coordinate to scroll at"),
+        dx: z.number().describe("Horizontal scroll amount (negative=left, positive=right)"),
+        dy: z.number().describe("Vertical scroll amount (negative=up, positive=down)"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ x, y, dx, dy, serial }) => {
       const s = await resolveSerial(serial);

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -195,8 +195,26 @@ export function registerInputTools(server: McpServer) {
       },
     },
     async ({ keycode, serial }) => {
+      let code: number;
+      try {
+        code = resolveKeycode(keycode);
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: true,
+                message: err.message,
+                hint: "Use a known keycode name (HOME, BACK, ENTER, VOLUME_UP, etc.) or a numeric value.",
+              }),
+            },
+          ],
+        };
+      }
+      
       const s = await resolveSerial(serial);
-      const code = resolveKeycode(keycode);
       await execAdbShell(s, `input keyevent ${code}`);
       return {
         content: [{ type: "text", text: `Sent key event: ${keycode} (${code})` }],

--- a/src/tools/vision.ts
+++ b/src/tools/vision.ts
@@ -11,11 +11,13 @@ interface RecordingSession {
 const recordingSessions: Map<string, RecordingSession> = new Map();
 
 export function registerVisionTools(server: McpServer) {
-  server.tool(
+  server.registerTool(
     "screenshot",
-    "Take a screenshot of the Android device screen. Returns the image as base64.",
     {
-      serial: z.string().optional().describe("Device serial number"),
+      description: "Take a screenshot of the Android device screen. Returns the image as base64.",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
     },
     async ({ serial }) => {
       const s = await resolveSerial(serial);
@@ -33,20 +35,22 @@ export function registerVisionTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "screen_record_start",
-    "Start recording the screen. Recording continues until screen_record_stop is called.",
     {
-      serial: z.string().optional().describe("Device serial number"),
-      remotePath: z
-        .string()
-        .optional()
-        .default("/sdcard/scrcpy-mcp-recording.mp4")
-        .describe("Path on device to save recording"),
-      duration: z
-        .number()
-        .optional()
-        .describe("Max recording duration in seconds (optional, device limit usually 180s)"),
+      description: "Start recording the screen. Recording continues until screen_record_stop is called.",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+        remotePath: z
+          .string()
+          .optional()
+          .default("/sdcard/scrcpy-mcp-recording.mp4")
+          .describe("Path on device to save recording"),
+        duration: z
+          .number()
+          .optional()
+          .describe("Max recording duration in seconds (optional, device limit usually 180s)"),
+      },
     },
     async ({ serial, remotePath, duration }) => {
       const s = await resolveSerial(serial);
@@ -90,20 +94,22 @@ export function registerVisionTools(server: McpServer) {
     }
   );
 
-  server.tool(
+  server.registerTool(
     "screen_record_stop",
-    "Stop screen recording and optionally pull the file to the host.",
     {
-      serial: z.string().optional().describe("Device serial number"),
-      pullToHost: z
-        .boolean()
-        .optional()
-        .default(false)
-        .describe("Pull the recording to the host machine"),
-      localPath: z
-        .string()
-        .optional()
-        .describe("Local path to save recording (only if pullToHost is true)"),
+      description: "Stop screen recording and optionally pull the file to the host.",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+        pullToHost: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Pull the recording to the host machine"),
+        localPath: z
+          .string()
+          .optional()
+          .describe("Local path to save recording (only if pullToHost is true)"),
+      },
     },
     async ({ serial, pullToHost, localPath }) => {
       const s = await resolveSerial(serial);


### PR DESCRIPTION
The server.tool() API is deprecated. Update all tool registrations to use the new server.registerTool() pattern with { description, inputSchema } object.

- Update device.ts: 6 tools migrated
- Update vision.ts: 3 tools migrated
- Update input.ts: 7 tools migrated
- Update AGENTS.md: reflect new registration pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tool registrations updated to use a unified descriptor format with per-tool input schemas for consistent parameter validation across device, input, and vision tools.

* **Bug Fixes**
  * Improved error handling and user-facing responses for device, connectivity, and input actions so failures return clear, structured messages instead of uncaught errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->