### PR TITLE
Implement scrcpy control protocol (2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .idea/
 coverage/
 *.tgz
+opencode.json

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,21 +80,21 @@ Implement the core scrcpy protocol for 10-50x faster performance. This is the ma
 
 ### 2.1 scrcpy Utility Layer Foundation (`src/utils/scrcpy.ts`)
 
-- [ ] 2.1.1 Define `ScrcpySession` class with properties: serial, controlSocket, videoProcess, frameBuffer, screenSize
-- [ ] 2.1.2 Implement `findScrcpyServer()` - locate scrcpy-server binary (SCRCPY_SERVER_PATH or auto-detect)
-- [ ] 2.1.3 Implement `pushScrcpyServer(serial)` - adb push scrcpy-server.jar to device
-- [ ] 2.1.4 Implement `setupPortForwarding(serial, port)` - adb forward tcp:port localabstract:scrcpy
-- [ ] 2.1.5 Implement `startScrcpyServer(serial, options)` - adb shell CLASSPATH... app_process
+- [x] 2.1.1 Define `ScrcpySession` class with properties: serial, controlSocket, videoProcess, frameBuffer, screenSize
+- [x] 2.1.2 Implement `findScrcpyServer()` - locate scrcpy-server binary (SCRCPY_SERVER_PATH or auto-detect)
+- [x] 2.1.3 Implement `pushScrcpyServer(serial)` - adb push scrcpy-server.jar to device
+- [x] 2.1.4 Implement `setupPortForwarding(serial, port)` - adb forward tcp:port localabstract:scrcpy
+- [x] 2.1.5 Implement `startScrcpyServer(serial, options)` - adb shell CLASSPATH... app_process
 
 ### 2.2 scrcpy Control Protocol
 
-- [ ] 2.2.1 Define control message type constants (INJECT_KEYCODE=0, INJECT_TEXT=1, etc.)
-- [ ] 2.2.2 Implement `serializeInjectKeycode(action, keycode, repeat, metaState)` - 14 bytes
-- [ ] 2.2.3 Implement `serializeInjectText(text)` - 5+len bytes, max 300 chars
-- [ ] 2.2.4 Implement `serializeInjectTouchEvent(action, pointerId, x, y, width, height, pressure, buttons)` - 32 bytes
-- [ ] 2.2.5 Implement `serializeInjectScrollEvent(x, y, width, height, hscroll, vscroll, buttons)` - 21 bytes
-- [ ] 2.2.6 Implement `serializeSetClipboard(sequence, paste, text)` - 14+len bytes
-- [ ] 2.2.7 Implement `serializeSimpleMessage(type)` - for EXPAND_NOTIFICATION_PANEL, COLLAPSE_PANELS, etc.
+- [x] 2.2.1 Define control message type constants (INJECT_KEYCODE=0, INJECT_TEXT=1, etc.)
+- [x] 2.2.2 Implement `serializeInjectKeycode(action, keycode, repeat, metaState)` - 14 bytes
+- [x] 2.2.3 Implement `serializeInjectText(text)` - 5+len bytes, max 300 chars
+- [x] 2.2.4 Implement `serializeInjectTouchEvent(action, pointerId, x, y, width, height, pressure, buttons)` - 32 bytes
+- [x] 2.2.5 Implement `serializeInjectScrollEvent(x, y, width, height, hscroll, vscroll, buttons)` - 21 bytes
+- [x] 2.2.6 Implement `serializeSetClipboard(sequence, paste, text)` - 14+len bytes
+- [x] 2.2.7 Implement `serializeSimpleMessage(type)` - for EXPAND_NOTIFICATION_PANEL, COLLAPSE_PANELS, etc.
 
 ### 2.3 scrcpy Video Stream
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,78 @@ export const SCRCPY_SERVER_PORT = 27183
 export const SCRCPY_SERVER_PATH_LOCAL = "/data/local/tmp/scrcpy-server.jar"
 
 export const SCRCPY_SERVER_VERSION = process.env.SCRCPY_SERVER_VERSION || "2.7"
+
+/**
+ * scrcpy Control Message Types
+ *
+ * These are the message type identifiers sent over the control socket to the
+ * scrcpy server running on the Android device. Each control message starts
+ * with a single byte indicating the message type, followed by type-specific
+ * payload data.
+ *
+ * Reference: https://github.com/Genymobile/scrcpy/blob/master/app/src/control_msg.h
+ */
+export const CONTROL_MSG_TYPE_INJECT_KEYCODE = 0
+export const CONTROL_MSG_TYPE_INJECT_TEXT = 1
+export const CONTROL_MSG_TYPE_INJECT_TOUCH_EVENT = 2
+export const CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT = 3
+export const CONTROL_MSG_TYPE_SET_DISPLAY_POWER = 4
+export const CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL = 5
+export const CONTROL_MSG_TYPE_EXPAND_SETTINGS_PANEL = 6
+export const CONTROL_MSG_TYPE_COLLAPSE_PANELS = 7
+export const CONTROL_MSG_TYPE_GET_CLIPBOARD = 8
+export const CONTROL_MSG_TYPE_SET_CLIPBOARD = 9
+export const CONTROL_MSG_TYPE_ROTATE_DEVICE = 10
+
+/**
+ * Touch Event Actions
+ *
+ * Android MotionEvent action codes used in INJECT_TOUCH_EVENT messages.
+ * These correspond to the standard Android touch event phases.
+ *
+ * - ACTION_DOWN: Finger/pointer has touched the screen
+ * - ACTION_UP: Finger/pointer has lifted from the screen
+ * - ACTION_MOVE: Finger/pointer is moving while touching the screen
+ */
+export const ACTION_DOWN = 0
+export const ACTION_UP = 1
+export const ACTION_MOVE = 2
+
+/**
+ * Display Power Modes
+ *
+ * Used with SET_DISPLAY_POWER to turn the screen on or off.
+ * This is more reliable than using key events for screen control.
+ */
+export const DISPLAY_POWER_MODE_OFF = 0
+export const DISPLAY_POWER_MODE_ON = 1
+
+/**
+ * Common Android Keycodes
+ *
+ * These are frequently used Android KeyEvent codes for INJECT_KEYCODE messages.
+ * Full list: https://developer.android.com/reference/android/view/KeyEvent
+ *
+ * - KEYCODE_HOME (3): Home button - returns to launcher
+ * - KEYCODE_BACK (4): Back button - navigates back
+ * - KEYCODE_VOLUME_UP (24): Volume up
+ * - KEYCODE_VOLUME_DOWN (25): Volume down
+ * - KEYCODE_POWER (26): Power button - toggles screen on/off
+ * - KEYCODE_ENTER (66): Enter/Return key
+ * - KEYCODE_MENU (82): Menu button (legacy)
+ */
+export const KEYCODE_HOME = 3
+export const KEYCODE_BACK = 4
+export const KEYCODE_VOLUME_UP = 24
+export const KEYCODE_VOLUME_DOWN = 25
+export const KEYCODE_POWER = 26
+export const KEYCODE_ENTER = 66
+export const KEYCODE_MENU = 82
+
+/**
+ * Maximum text length for INJECT_TEXT messages
+ *
+ * scrcpy limits text injection to 300 bytes to prevent excessively large
+ * messages on the control socket. For longer text, split into multiple calls.
+ */
+export const TEXT_MAX_LENGTH = 300

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -70,11 +70,13 @@ export function serializeInjectText(text: string): Buffer {
 }
 
 const floatToU16FP = (f: number): number => {
+  f = Math.max(0, Math.min(f, 1))
   const u = Math.round(f * 65536)
   return Math.min(u, 0xffff)
 }
 
 const floatToI16FP = (f: number): number => {
+  f = Math.max(-1, Math.min(f, 1))
   const i = Math.round(f * 32768)
   return Math.max(-0x8000, Math.min(i, 0x7fff))
 }


### PR DESCRIPTION
Add control message serializers for fast scrcpy input path:
- serializeInjectKeycode, serializeInjectText, serializeInjectTouchEvent
- serializeInjectScrollEvent, serializeSetDisplayPower
- serializeSetClipboard, serializeGetClipboard
- Simple message serializers (expand/collapse panels, rotate)
- sendControlMessage helper

Move protocol constants to constants.ts with documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive device control: key and text input, touch & scroll events, display power, panel controls, clipboard operations, and device rotation.

* **Documentation**
  * Roadmap updated: Phase 2 utility layer and control protocol tasks marked completed.

* **Chores**
  * opencode.json added to .gitignore (now ignored by version control).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->