### PR TITLE
Implement scrcpy video stream (2.3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,11 +98,11 @@ Implement the core scrcpy protocol for 10-50x faster performance. This is the ma
 
 ### 2.3 scrcpy Video Stream
 
-- [ ] 2.3.1 Implement `startVideoStream(session)` - spawn ffmpeg to decode H.264
-- [ ] 2.3.2 Handle video socket data and pipe to ffmpeg stdin
-- [ ] 2.3.3 Capture decoded frames from ffmpeg stdout
-- [ ] 2.3.4 Store latest frame in session.frameBuffer
-- [ ] 2.3.5 Implement `getLatestFrame()` method
+- [x] 2.3.1 Implement `startVideoStream(session)` - spawn ffmpeg to decode H.264
+- [x] 2.3.2 Handle video socket data and pipe to ffmpeg stdin
+- [x] 2.3.3 Capture decoded frames from ffmpeg stdout
+- [x] 2.3.4 Store latest frame in session.frameBuffer
+- [x] 2.3.5 Implement `getLatestFrame()` method
 
 ### 2.4 scrcpy Session Management
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -82,3 +82,8 @@ export const KEYCODE_MENU = 82
  * messages on the control socket. For longer text, split into multiple calls.
  */
 export const TEXT_MAX_LENGTH = 300
+
+export const JPEG_SOI = 0xffd8
+export const JPEG_EOI = 0xffd9
+
+export const MAX_JPEG_BUFFER_SIZE = 10 * 1024 * 1024

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -236,7 +236,7 @@ function startVideoStream(session: ScrcpySession, videoSocket: net.Socket): void
     jpegBuffer = Buffer.concat([jpegBuffer, chunk])
 
     if (jpegBuffer.length > MAX_JPEG_BUFFER_SIZE) {
-      console.error(`[scrcpy] JPEG buffer exceeded max size, resetting`)
+      console.error(`[scrcpy] [${session.serial}] JPEG buffer exceeded max size, resetting`)
       jpegBuffer = Buffer.alloc(0)
       return
     }
@@ -277,7 +277,7 @@ function startVideoStream(session: ScrcpySession, videoSocket: net.Socket): void
   })
 
   ffmpeg.stderr?.on("data", (data: Buffer) => {
-    console.error(`[scrcpy] ffmpeg stderr: ${data.toString().trim()}`)
+    console.error(`[scrcpy] [${session.serial}] ffmpeg stderr: ${data.toString().trim()}`)
   })
 
   ffmpeg.on("error", (err: Error) => {

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -556,18 +556,23 @@ export async function startSession(
     startVideoStream(session, socket)
 
     let controlSocket: net.Socket | null = null
+    let lastControlError: Error | null = null
     const controlConnectDeadline = Date.now() + 5000
     while (Date.now() < controlConnectDeadline) {
       try {
         controlSocket = await connectToServer(port)
         break
-      } catch {
+      } catch (err) {
+        lastControlError = err as Error
         await new Promise((resolve) => setTimeout(resolve, 100))
       }
     }
 
     if (!controlSocket) {
-      throw new Error(`Failed to connect control socket on port ${port} within timeout`)
+      throw new Error(
+        `Failed to connect control socket on port ${port} for device ${s} within timeout`,
+        { cause: lastControlError }
+      )
     }
 
     session.controlSocket = controlSocket


### PR DESCRIPTION
- Add startVideoStream() to spawn ffmpeg for H.264 decoding
- Connect separate video socket and pipe to ffmpeg stdin
- Parse MJPEG output to extract complete JPEG frames
- Store latest frame in session.frameBuffer
- Add getLatestFrame() to retrieve current frame
- Update ScrcpySession interface with videoSocket
- Clean up video resources in stopSession()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video streaming is fully implemented and now starts automatically when a session begins.
  * Retrieve the most recently captured video frame from any active session via a new API.
  * Sessions use a dedicated video connection for more reliable real-time streaming and improved cleanup on stop.

* **Documentation**
  * Roadmap checklist items for video streaming marked as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->