### PR TITLE
Implement scrcpy session management (2.4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,11 +106,11 @@ Implement the core scrcpy protocol for 10-50x faster performance. This is the ma
 
 ### 2.4 scrcpy Session Management
 
-- [ ] 2.4.1 Implement `startSession(serial, options)` - full lifecycle: push, forward, start server, connect sockets
-- [ ] 2.4.2 Implement `stopSession(serial)` - cleanup: close sockets, kill processes, remove forwarding
-- [ ] 2.4.3 Implement `getSession(serial)` - retrieve active session
-- [ ] 2.4.4 Implement `hasActiveSession(serial)` - check if session exists and is connected
-- [ ] 2.4.5 Handle device messages (CLIPBOARD) from server
+- [x] 2.4.1 Implement `startSession(serial, options)` - full lifecycle: push, forward, start server, connect sockets
+- [x] 2.4.2 Implement `stopSession(serial)` - cleanup: close sockets, kill processes, remove forwarding
+- [x] 2.4.3 Implement `getSession(serial)` - retrieve active session
+- [x] 2.4.4 Implement `hasActiveSession(serial)` - check if session exists and is connected
+- [x] 2.4.5 Handle device messages (CLIPBOARD) from server
 
 ### 2.5 Session Tools (`src/tools/session.ts`)
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -30,6 +30,8 @@ export const CONTROL_MSG_TYPE_GET_CLIPBOARD = 8
 export const CONTROL_MSG_TYPE_SET_CLIPBOARD = 9
 export const CONTROL_MSG_TYPE_ROTATE_DEVICE = 10
 
+export const DEVICE_MSG_TYPE_CLIPBOARD = 0
+
 /**
  * Touch Event Actions
  *

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -89,3 +89,5 @@ export const JPEG_SOI = 0xffd8
 export const JPEG_EOI = 0xffd9
 
 export const MAX_JPEG_BUFFER_SIZE = 10 * 1024 * 1024
+
+export const MAX_CLIPBOARD_BYTES = 1024 * 1024

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -504,8 +504,6 @@ const startDeviceMessageHandler = (session: ScrcpySession): void => {
       const msgType = messageBuffer.readUInt8(0)
 
       if (msgType === DEVICE_MSG_TYPE_CLIPBOARD) {
-        if (messageBuffer.length < 5) break
-
         const textLength = messageBuffer.readUInt32BE(1)
 
         if (messageBuffer.length < 5 + textLength) break
@@ -515,8 +513,8 @@ const startDeviceMessageHandler = (session: ScrcpySession): void => {
 
         messageBuffer = messageBuffer.subarray(5 + textLength)
       } else {
-        console.error(`[scrcpy] Unknown device message type: ${msgType}`)
-        messageBuffer = messageBuffer.subarray(1)
+        console.error(`[scrcpy] Unknown device message type: ${msgType}, resetting buffer`)
+        messageBuffer = Buffer.alloc(0)
       }
     }
   })

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -492,7 +492,7 @@ const receiveDeviceMeta = async (
     socket.on("error", onError)
   })
 
-function startDeviceMessageHandler(session: ScrcpySession): void {
+const startDeviceMessageHandler = (session: ScrcpySession): void => {
   if (!session.controlSocket) return
 
   let messageBuffer = Buffer.alloc(0)


### PR DESCRIPTION
- Add DEVICE_MSG_TYPE_CLIPBOARD constant for device messages
- Add clipboardContent field to ScrcpySession interface
- Implement startDeviceMessageHandler for clipboard sync
- Fix null-check issues in startSession using currentSession alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device clipboard support: clipboard content can be received and accessed within active sessions.

* **Session Management**
  * Session lifecycle commands (start, stop, query, active-check) are implemented; session state now tracks clipboard updates.

* **Documentation**
  * Roadmap updated to mark session-management items as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->