### PR TITLE
Implement phase 2.7: wire scrcpy fast path for screenshot

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,8 +130,8 @@ Implement the core scrcpy protocol for 10-50x faster performance. This is the ma
 
 ### 2.7 Wire scrcpy Fast Path - Vision Tools
 
-- [ ] 2.7.1 Update `screenshot` - use scrcpy frame buffer when session active (~33ms)
-- [ ] 2.7.2 Keep ADB fallback for when no session (~500ms)
+- [x] 2.7.1 Update `screenshot` - use scrcpy frame buffer when session active (~33ms)
+- [x] 2.7.2 Keep ADB fallback for when no session (~500ms)
 
 ### 2.8 Wire scrcpy Fast Path - Device Tools
 


### PR DESCRIPTION
- Update screenshot tool to use scrcpy frame buffer when session active (~33ms)
- Fall back to ADB screencap when no session (~500ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Screenshot performance dramatically enhanced when using an active device session, with latency reduced from approximately 500ms to 33ms, enabling faster visual feedback.
  * Intelligent fallback system automatically maintains compatibility and reliability across all operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->