### PR TITLE
Implement phase 2.8: wire scrcpy fast path for device tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,12 +135,12 @@ Implement the core scrcpy protocol for 10-50x faster performance. This is the ma
 
 ### 2.8 Wire scrcpy Fast Path - Device Tools
 
-- [ ] 2.8.1 Implement `screen_on` - use scrcpy SET_DISPLAY_POWER (on=true)
-- [ ] 2.8.2 Implement `screen_off` - use scrcpy SET_DISPLAY_POWER (on=false)
-- [ ] 2.8.3 Implement `rotate_device` - use scrcpy ROTATE_DEVICE
-- [ ] 2.8.4 Implement `expand_notifications` - use scrcpy EXPAND_NOTIFICATION_PANEL (scrcpy only, no ADB fallback)
-- [ ] 2.8.5 Implement `expand_settings` - use scrcpy EXPAND_SETTINGS_PANEL (scrcpy only, no ADB fallback)
-- [ ] 2.8.6 Implement `collapse_panels` - use scrcpy COLLAPSE_PANELS (scrcpy only, no ADB fallback)
+- [x] 2.8.1 Implement `screen_on` - use scrcpy SET_DISPLAY_POWER (on=true)
+- [x] 2.8.2 Implement `screen_off` - use scrcpy SET_DISPLAY_POWER (on=false)
+- [x] 2.8.3 Implement `rotate_device` - use scrcpy ROTATE_DEVICE
+- [x] 2.8.4 Implement `expand_notifications` - use scrcpy EXPAND_NOTIFICATION_PANEL (scrcpy only, no ADB fallback)
+- [x] 2.8.5 Implement `expand_settings` - use scrcpy EXPAND_SETTINGS_PANEL (scrcpy only, no ADB fallback)
+- [x] 2.8.6 Implement `collapse_panels` - use scrcpy COLLAPSE_PANELS (scrcpy only, no ADB fallback)
 
 ### 2.9 Wire scrcpy Fast Path - Clipboard Tools
 

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -25,7 +25,8 @@ const requireActiveSession = (
   if (!hasActiveSession(serial)) {
     return {
       error: true,
-      message: `${toolName} requires an active scrcpy session for device ${serial}. Start a session first with start_session.`,
+      message: `${toolName} requires an active scrcpy session for device ${serial}. ` +
+        `Start a session first with start_session.`,
     }
   }
   return null
@@ -270,33 +271,38 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
+      let s = "unknown"
       try {
-        const s = await resolveSerial(serial);
+        s = await resolveSerial(serial)
 
-        const sessionError = requireActiveSession(s, "rotate_device");
+        const sessionError = requireActiveSession(s, "rotate_device")
         if (sessionError) {
           return {
             content: [{ type: "text", text: JSON.stringify(sessionError) }],
-          };
+          }
         }
 
-        sendControlMessage(s, serializeRotateDevice());
+        sendControlMessage(s, serializeRotateDevice())
         return {
           content: [{ type: "text", text: `Device rotated for ${s}` }],
-        };
+        }
       } catch (error) {
-        const err = error as Error;
+        const err = error as Error
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ error: true, message: `Failed to rotate device: ${err.message}` }),
+              text: JSON.stringify({
+                error: true,
+                serial: s || "unknown",
+                message: `Failed to rotate device: ${err.message}`,
+              }),
             },
           ],
-        };
+        }
       }
     }
-  );
+  )
 
   server.registerTool(
     "expand_notifications",
@@ -307,33 +313,38 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
+      let s = "unknown"
       try {
-        const s = await resolveSerial(serial);
+        s = await resolveSerial(serial)
 
-        const sessionError = requireActiveSession(s, "expand_notifications");
+        const sessionError = requireActiveSession(s, "expand_notifications")
         if (sessionError) {
           return {
             content: [{ type: "text", text: JSON.stringify(sessionError) }],
-          };
+          }
         }
 
-        sendControlMessage(s, serializeExpandNotificationPanel());
+        sendControlMessage(s, serializeExpandNotificationPanel())
         return {
           content: [{ type: "text", text: `Notification panel expanded for ${s}` }],
-        };
+        }
       } catch (error) {
-        const err = error as Error;
+        const err = error as Error
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ error: true, message: `Failed to expand notifications: ${err.message}` }),
+              text: JSON.stringify({
+                error: true,
+                serial: s,
+                message: `Failed to expand notifications: ${err.message}`,
+              }),
             },
           ],
-        };
+        }
       }
     }
-  );
+  )
 
   server.registerTool(
     "expand_settings",
@@ -344,33 +355,38 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
+      let s = "unknown"
       try {
-        const s = await resolveSerial(serial);
+        s = await resolveSerial(serial)
 
-        const sessionError = requireActiveSession(s, "expand_settings");
+        const sessionError = requireActiveSession(s, "expand_settings")
         if (sessionError) {
           return {
             content: [{ type: "text", text: JSON.stringify(sessionError) }],
-          };
+          }
         }
 
-        sendControlMessage(s, serializeExpandSettingsPanel());
+        sendControlMessage(s, serializeExpandSettingsPanel())
         return {
           content: [{ type: "text", text: `Quick settings panel expanded for ${s}` }],
-        };
+        }
       } catch (error) {
-        const err = error as Error;
+        const err = error as Error
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ error: true, message: `Failed to expand settings: ${err.message}` }),
+              text: JSON.stringify({
+                error: true,
+                serial: s,
+                message: `Failed to expand settings: ${err.message}`,
+              }),
             },
           ],
-        };
+        }
       }
     }
-  );
+  )
 
   server.registerTool(
     "collapse_panels",
@@ -381,31 +397,36 @@ export function registerDeviceTools(server: McpServer) {
       },
     },
     async ({ serial }) => {
+      let s = "unknown"
       try {
-        const s = await resolveSerial(serial);
+        s = await resolveSerial(serial)
 
-        const sessionError = requireActiveSession(s, "collapse_panels");
+        const sessionError = requireActiveSession(s, "collapse_panels")
         if (sessionError) {
           return {
             content: [{ type: "text", text: JSON.stringify(sessionError) }],
-          };
+          }
         }
 
-        sendControlMessage(s, serializeCollapsePanels());
+        sendControlMessage(s, serializeCollapsePanels())
         return {
           content: [{ type: "text", text: `Panels collapsed for ${s}` }],
-        };
+        }
       } catch (error) {
-        const err = error as Error;
+        const err = error as Error
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify({ error: true, message: `Failed to collapse panels: ${err.message}` }),
+              text: JSON.stringify({
+                error: true,
+                serial: s,
+                message: `Failed to collapse panels: ${err.message}`,
+              }),
             },
           ],
-        };
+        }
       }
     }
-  );
+  )
 }

--- a/src/tools/device.ts
+++ b/src/tools/device.ts
@@ -1,5 +1,5 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
 import {
   getDevices,
   execAdbShell,
@@ -7,7 +7,29 @@ import {
   getScreenSize,
   getDeviceProperty,
   execAdb,
-} from "../utils/adb.js";
+} from "../utils/adb.js"
+import {
+  hasActiveSession,
+  sendControlMessage,
+  serializeSetDisplayPower,
+  serializeRotateDevice,
+  serializeExpandNotificationPanel,
+  serializeExpandSettingsPanel,
+  serializeCollapsePanels,
+} from "../utils/scrcpy.js"
+
+const requireActiveSession = (
+  serial: string,
+  toolName: string
+): { error: true; message: string } | null => {
+  if (!hasActiveSession(serial)) {
+    return {
+      error: true,
+      message: `${toolName} requires an active scrcpy session for device ${serial}. Start a session first with start_session.`,
+    }
+  }
+  return null
+}
 
 export function registerDeviceTools(server: McpServer) {
   server.registerTool(
@@ -92,6 +114,14 @@ export function registerDeviceTools(server: McpServer) {
     async ({ serial }) => {
       try {
         const s = await resolveSerial(serial);
+        
+        if (hasActiveSession(s)) {
+          sendControlMessage(s, serializeSetDisplayPower(true));
+          return {
+            content: [{ type: "text", text: `Screen turned on for device ${s} (via scrcpy)` }],
+          };
+        }
+        
         await execAdbShell(s, "input keyevent KEYCODE_WAKEUP");
         return {
           content: [{ type: "text", text: `Screen turned on for device ${s}` }],
@@ -121,6 +151,14 @@ export function registerDeviceTools(server: McpServer) {
     async ({ serial }) => {
       try {
         const s = await resolveSerial(serial);
+        
+        if (hasActiveSession(s)) {
+          sendControlMessage(s, serializeSetDisplayPower(false));
+          return {
+            content: [{ type: "text", text: `Screen turned off for device ${s} (via scrcpy)` }],
+          };
+        }
+        
         await execAdbShell(s, "input keyevent KEYCODE_SLEEP");
         return {
           content: [{ type: "text", text: `Screen turned off for device ${s}` }],
@@ -218,6 +256,154 @@ export function registerDeviceTools(server: McpServer) {
         const err = error as Error;
         return {
           content: [{ type: "text", text: JSON.stringify({ error: true, message: `Failed to disconnect from ${address}: ${err.message}` }) }],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "rotate_device",
+    {
+      description: "Rotate the device screen (requires active scrcpy session)",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ serial }) => {
+      try {
+        const s = await resolveSerial(serial);
+
+        const sessionError = requireActiveSession(s, "rotate_device");
+        if (sessionError) {
+          return {
+            content: [{ type: "text", text: JSON.stringify(sessionError) }],
+          };
+        }
+
+        sendControlMessage(s, serializeRotateDevice());
+        return {
+          content: [{ type: "text", text: `Device rotated for ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to rotate device: ${err.message}` }),
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "expand_notifications",
+    {
+      description: "Expand the notification panel (requires active scrcpy session)",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ serial }) => {
+      try {
+        const s = await resolveSerial(serial);
+
+        const sessionError = requireActiveSession(s, "expand_notifications");
+        if (sessionError) {
+          return {
+            content: [{ type: "text", text: JSON.stringify(sessionError) }],
+          };
+        }
+
+        sendControlMessage(s, serializeExpandNotificationPanel());
+        return {
+          content: [{ type: "text", text: `Notification panel expanded for ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to expand notifications: ${err.message}` }),
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "expand_settings",
+    {
+      description: "Expand the quick settings panel (requires active scrcpy session)",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ serial }) => {
+      try {
+        const s = await resolveSerial(serial);
+
+        const sessionError = requireActiveSession(s, "expand_settings");
+        if (sessionError) {
+          return {
+            content: [{ type: "text", text: JSON.stringify(sessionError) }],
+          };
+        }
+
+        sendControlMessage(s, serializeExpandSettingsPanel());
+        return {
+          content: [{ type: "text", text: `Quick settings panel expanded for ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to expand settings: ${err.message}` }),
+            },
+          ],
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "collapse_panels",
+    {
+      description: "Collapse all open panels (notification, settings) (requires active scrcpy session)",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ serial }) => {
+      try {
+        const s = await resolveSerial(serial);
+
+        const sessionError = requireActiveSession(s, "collapse_panels");
+        if (sessionError) {
+          return {
+            content: [{ type: "text", text: JSON.stringify(sessionError) }],
+          };
+        }
+
+        sendControlMessage(s, serializeCollapsePanels());
+        return {
+          content: [{ type: "text", text: `Panels collapsed for ${s}` }],
+        };
+      } catch (error) {
+        const err = error as Error;
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ error: true, message: `Failed to collapse panels: ${err.message}` }),
+            },
+          ],
         };
       }
     }


### PR DESCRIPTION
- Update screen_on/screen_off to use scrcpy SET_DISPLAY_POWER when session active
- Add rotate_device tool using scrcpy ROTATE_DEVICE
- Add expand_notifications tool using scrcpy EXPAND_NOTIFICATION_PANEL
- Add expand_settings tool using scrcpy EXPAND_SETTINGS_PANEL
- Add collapse_panels tool using scrcpy COLLAPSE_PANELS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device rotation and panel controls: rotate device, expand notifications, expand quick settings, and collapse panels.
  * Screen on/off now detects and uses active remote-display sessions for faster, more reliable behavior.
  * Improved error responses for device control actions for clearer failure feedback.

* **Chores**
  * Roadmap: six tasks in section 2.8 marked completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->