### PR TITLE
feat(phase-4): implement shell, file transfer tools and complete phase 4

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -202,24 +202,24 @@ Complete the tool set with shell, file, and remaining device tools.
 
 ### 4.1 Shell Tools (`src/tools/shell.ts`)
 
-- [ ] 4.1.1 Implement `shell_exec` - arbitrary ADB shell command execution
+- [x] 4.1.1 Implement `shell_exec` - arbitrary ADB shell command execution
 
 ### 4.2 File Transfer Tools (`src/tools/files.ts`)
 
-- [ ] 4.2.1 Implement `file_push` - ADB `push`
-- [ ] 4.2.2 Implement `file_pull` - ADB `pull`
-- [ ] 4.2.3 Implement `file_list` - ADB `ls -la` with parsing
+- [x] 4.2.1 Implement `file_push` - ADB `push`
+- [x] 4.2.2 Implement `file_pull` - ADB `pull`
+- [x] 4.2.3 Implement `file_list` - ADB `ls -la` with parsing
 
 ### 4.3 Screen Recording Tools (update `src/tools/vision.ts`)
 
-- [ ] 4.3.1 Ensure `screen_record_start` works via ADB `screenrecord`
-- [ ] 4.3.2 Ensure `screen_record_stop` properly terminates recording
+- [x] 4.3.1 Ensure `screen_record_start` works via ADB `screenrecord`
+- [x] 4.3.2 Ensure `screen_record_stop` properly terminates recording
 
 ### 4.4 Testing
 
-- [ ] 4.4.1 Test shell_exec with various commands
-- [ ] 4.4.2 Test file push/pull
-- [ ] 4.4.3 Test screen recording
+- [x] 4.4.1 Test shell_exec with various commands
+- [x] 4.4.2 Test file push/pull
+- [x] 4.4.3 Test screen recording
 
 **Phase 4 Milestone:** All 34 tools implemented.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { registerInputTools } from "./tools/input.js"
 import { registerAppTools } from "./tools/apps.js"
 import { registerClipboardTools } from "./tools/clipboard.js"
 import { registerUiTools } from "./tools/ui.js"
+import { registerShellTools } from "./tools/shell.js"
+import { registerFileTools } from "./tools/files.js"
 
 const server = new McpServer({
   name: "scrcpy-mcp",
@@ -22,6 +24,8 @@ registerInputTools(server)
 registerAppTools(server)
 registerClipboardTools(server)
 registerUiTools(server)
+registerShellTools(server)
+registerFileTools(server)
 
 async function main() {
   const transport = new StdioServerTransport()

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -1,0 +1,169 @@
+import * as nodePath from "path"
+import * as fs from "fs"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+import { execAdb, execAdbShell, resolveSerial } from "../utils/adb.js"
+
+export interface FileEntry {
+  name: string
+  permissions: string
+  owner: string
+  group: string
+  size: number
+  date: string
+  isDirectory: boolean
+}
+
+export function parseLsOutput(output: string): FileEntry[] {
+  const entries: FileEntry[] = []
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith("total ")) continue
+
+    // Matches: permissions links owner group size YYYY-MM-DD HH:MM name
+    // Handles optional SELinux suffix (. or +) on permissions field
+    const match = trimmed.match(
+      /^([dlbcsp-][rwxst-]{9}[+.]?)\s+\d+\s+(\S+)\s+(\S+)\s+(\d+)\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})\s+(.+)$/
+    )
+    if (!match) continue
+
+    const [, permissions, owner, group, sizeStr, date, namePart] = match
+    // Strip symlink target (e.g. "link -> /path/to/target")
+    const name = namePart.split(" -> ")[0].trim()
+
+    entries.push({
+      name,
+      permissions,
+      owner,
+      group,
+      size: parseInt(sizeStr, 10),
+      date,
+      isDirectory: permissions.startsWith("d"),
+    })
+  }
+  return entries
+}
+
+export function registerFileTools(server: McpServer): void {
+  server.registerTool(
+    "file_push",
+    {
+      description: "Push a file from the host machine to the device.",
+      inputSchema: {
+        localPath: z.string().describe("Absolute path to the file on the host machine"),
+        remotePath: z.string().describe("Destination path on the device (e.g., /sdcard/myfile.txt)"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ localPath, remotePath, serial }) => {
+      try {
+        if (!nodePath.isAbsolute(localPath)) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ error: true, message: "localPath must be an absolute path" }),
+            }],
+          }
+        }
+        if (!fs.existsSync(localPath)) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ error: true, message: `File not found: ${localPath}` }),
+            }],
+          }
+        }
+        const s = await resolveSerial(serial)
+        const { stdout, stderr } = await execAdb(["-s", s, "push", localPath, remotePath])
+        const output = (stdout + stderr).trim()
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ success: true, message: output || `Pushed ${localPath} to ${remotePath}` }),
+          }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: true, message: err.message }),
+          }],
+        }
+      }
+    }
+  )
+
+  server.registerTool(
+    "file_pull",
+    {
+      description: "Pull a file from the device to the host machine.",
+      inputSchema: {
+        remotePath: z.string().describe("Path to the file on the device (e.g., /sdcard/myfile.txt)"),
+        localPath: z.string().describe("Destination absolute path on the host machine"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ remotePath, localPath, serial }) => {
+      try {
+        if (!nodePath.isAbsolute(localPath)) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({ error: true, message: "localPath must be an absolute path" }),
+            }],
+          }
+        }
+        const s = await resolveSerial(serial)
+        const { stdout, stderr } = await execAdb(["-s", s, "pull", remotePath, localPath])
+        const output = (stdout + stderr).trim()
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ success: true, message: output || `Pulled ${remotePath} to ${localPath}` }),
+          }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: true, message: err.message }),
+          }],
+        }
+      }
+    }
+  )
+
+  server.registerTool(
+    "file_list",
+    {
+      description: "List directory contents on the device.",
+      inputSchema: {
+        path: z.string().describe("Absolute path to the directory on the device (e.g., /sdcard/)"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ path: devicePath, serial }) => {
+      try {
+        const s = await resolveSerial(serial)
+        const output = await execAdbShell(s, `ls -la "${devicePath}"`)
+        const entries = parseLsOutput(output)
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ path: devicePath, count: entries.length, entries }),
+          }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: true, message: err.message }),
+          }],
+        }
+      }
+    }
+  )
+}

--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -1,0 +1,35 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+import { execAdbShell, resolveSerial } from "../utils/adb.js"
+
+export function registerShellTools(server: McpServer): void {
+  server.registerTool(
+    "shell_exec",
+    {
+      description:
+        "Execute an arbitrary ADB shell command on the device and return the output. " +
+        "Use this for any device operation not covered by other tools.",
+      inputSchema: {
+        command: z.string().describe("Shell command to execute on the device"),
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ command, serial }) => {
+      try {
+        const s = await resolveSerial(serial)
+        const output = await execAdbShell(s, command)
+        return {
+          content: [{ type: "text", text: output }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: true, message: err.message }),
+          }],
+        }
+      }
+    }
+  )
+}

--- a/tests/files.test.ts
+++ b/tests/files.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+import { parseLsOutput } from "../src/tools/files.js"
+
+// Typical Android toybox ls -la output
+const SAMPLE_LS = `total 48
+drwxrwxrwx  8 root sdcard_rw  4096 2024-03-10 09:00 .
+drwxr-xr-x 23 root root       4096 2024-01-01 00:00 ..
+drwxrwxrwx  2 root sdcard_rw  4096 2024-03-10 08:00 DCIM
+drwxrwxrwx  3 root sdcard_rw  4096 2024-02-14 12:30 Android
+-rw-rw----  1 root sdcard_rw  1024 2024-03-10 09:15 notes.txt
+-rw-rw----  1 root sdcard_rw 98304 2024-03-09 18:45 video.mp4
+lrwxrwxrwx  1 root root          7 2024-01-01 00:00 sdcard -> /sdcard`
+
+describe("parseLsOutput", () => {
+  it("parses all entries (excluding total line)", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    expect(entries.length).toBe(7) // . .. DCIM Android notes.txt video.mp4 sdcard
+  })
+
+  it("identifies directories by permissions", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const dirs = entries.filter((e) => e.isDirectory)
+    expect(dirs.length).toBe(4) // . .. DCIM Android
+    expect(dirs.map((d) => d.name)).toContain("DCIM")
+    expect(dirs.map((d) => d.name)).toContain("Android")
+  })
+
+  it("identifies regular files", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const files = entries.filter((e) => !e.isDirectory)
+    expect(files.length).toBe(3) // notes.txt video.mp4 sdcard (symlink)
+  })
+
+  it("parses file name", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const notes = entries.find((e) => e.name === "notes.txt")
+    expect(notes).toBeDefined()
+  })
+
+  it("parses permissions correctly", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const notes = entries.find((e) => e.name === "notes.txt")
+    expect(notes?.permissions).toBe("-rw-rw----")
+  })
+
+  it("parses owner and group", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const notes = entries.find((e) => e.name === "notes.txt")
+    expect(notes?.owner).toBe("root")
+    expect(notes?.group).toBe("sdcard_rw")
+  })
+
+  it("parses size as a number", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const notes = entries.find((e) => e.name === "notes.txt")
+    expect(notes?.size).toBe(1024)
+    const video = entries.find((e) => e.name === "video.mp4")
+    expect(video?.size).toBe(98304)
+  })
+
+  it("parses date string", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const notes = entries.find((e) => e.name === "notes.txt")
+    expect(notes?.date).toBe("2024-03-10 09:15")
+  })
+
+  it("strips symlink target from name", () => {
+    const entries = parseLsOutput(SAMPLE_LS)
+    const link = entries.find((e) => e.name === "sdcard")
+    expect(link).toBeDefined()
+    expect(link?.name).toBe("sdcard")
+    expect(link?.name).not.toContain("->")
+  })
+
+  it("returns empty array for empty output", () => {
+    expect(parseLsOutput("")).toHaveLength(0)
+  })
+
+  it("returns empty array for only a total line", () => {
+    expect(parseLsOutput("total 0")).toHaveLength(0)
+  })
+
+  it("skips unrecognised lines", () => {
+    const output = "total 0\nnot a valid ls line\n-rw-r--r-- 1 root root 5 2024-01-01 00:00 file.txt"
+    const entries = parseLsOutput(output)
+    expect(entries.length).toBe(1)
+    expect(entries[0].name).toBe("file.txt")
+  })
+
+  it("handles optional SELinux suffix (.) on permissions", () => {
+    const output = "total 0\n-rw-r--r--. 1 root root 10 2024-01-01 00:00 selinux.txt"
+    const entries = parseLsOutput(output)
+    expect(entries.length).toBe(1)
+    expect(entries[0].name).toBe("selinux.txt")
+    expect(entries[0].permissions).toBe("-rw-r--r--.")
+  })
+
+  it("handles optional SELinux suffix (+) on permissions", () => {
+    const output = "total 0\ndrwxrwx--x+ 4 root sdcard_rw 4096 2024-01-01 00:00 shared"
+    const entries = parseLsOutput(output)
+    expect(entries.length).toBe(1)
+    expect(entries[0].isDirectory).toBe(true)
+    expect(entries[0].name).toBe("shared")
+  })
+})


### PR DESCRIPTION
- Add shell_exec tool (src/tools/shell.ts): executes arbitrary ADB shell commands, returns output as text
- Add file_push, file_pull, file_list tools (src/tools/files.ts): ADB-based file transfer and directory listing with structured JSON output; export parseLsOutput for unit testing
- Register new tools in src/index.ts
- Add 14 unit tests for parseLsOutput covering directories, files, symlinks, SELinux permission suffixes, and edge cases (tests/files.test.ts)
- Mark all Phase 4 ROADMAP items done; screen recording tools (4.3) were already implemented in vision.ts, verified on device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell command execution on devices
  * File transfer tools: upload, download, and directory listing
  * Screen recording start/stop controls

* **Tests**
  * Added tests for shell execution, file transfer, and directory-list parsing

* **Documentation**
  * Roadmap updated to mark Phase 4 tooling milestones complete
<!-- end of auto-generated comment: release notes by coderabbit.ai -->