### PR TITLE
feat(phase-5): add registry listings for Smithery and official MCP Re…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,25 @@ jobs:
         if: steps.version_check.outputs.changed == 'true'
         run: npm publish --provenance --access public
 
+      - name: Install mcp-publisher
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Update server.json version
+        if: steps.version_check.outputs.changed == 'true'
+        run: |
+          VERSION=${{ steps.version_check.outputs.current }}
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        if: steps.version_check.outputs.changed == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: steps.version_check.outputs.changed == 'true'
+        run: ./mcp-publisher publish
+
       - name: Create git tag
         if: steps.version_check.outputs.changed == 'true'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,13 +53,22 @@ jobs:
       - name: Install mcp-publisher
         if: steps.version_check.outputs.changed == 'true'
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          MCP_VERSION="v1.4.1"
+          VERSION_NUM="${MCP_VERSION#v}"
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          TARBALL="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_VERSION}/${TARBALL}" -o "${TARBALL}"
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_VERSION}/registry_${VERSION_NUM}_checksums.txt" -o checksums.txt
+          grep "${TARBALL}" checksums.txt | sha256sum --check
+          tar xzf "${TARBALL}" mcp-publisher
+          rm "${TARBALL}" checksums.txt
 
       - name: Update server.json version
         if: steps.version_check.outputs.changed == 'true'
         run: |
           VERSION=${{ steps.version_check.outputs.current }}
-          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+          jq --arg v "$VERSION" '.version = $v | .packages[].version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Authenticate to MCP Registry
         if: steps.version_check.outputs.changed == 'true'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -250,11 +250,11 @@ Prepare for distribution.
 
 ### 5.3 Registry Listings
 
-- [ ] 5.3.1 Create `smithery.yaml` and submit to [smithery.ai](https://smithery.ai)
-- [ ] 5.3.2 Submit to the [Official MCP Registry](https://registry.modelcontextprotocol.io):
-  - Build publisher CLI: `make publisher`
-  - Authenticate via GitHub OAuth
-  - Publish as `io.github.JuanCF/scrcpy-mcp`
+- [x] 5.3.1 Create `smithery.yaml` and submit to [smithery.ai](https://smithery.ai)
+- [x] 5.3.2 Submit to the [Official MCP Registry](https://registry.modelcontextprotocol.io):
+  - Automated via CI: `mcp-publisher` authenticates using GitHub Actions OIDC (no secrets needed)
+  - Publishes as `io.github.JuanCF/scrcpy-mcp` on every version bump to `main`
+  - Manual fallback: `mcp-publisher login github && mcp-publisher publish`
 
 **Phase 5 Milestone:** Published on npm, installable via `npx scrcpy-mcp`, listed on Smithery and the official MCP Registry.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -248,12 +248,15 @@ Prepare for distribution.
 - [x] 5.2.4 Test on real Android device
 - [x] 5.2.5 Test both scrcpy path and ADB fallback
 
-### 5.3 Optional: Smithery Listing
+### 5.3 Registry Listings
 
-- [ ] 5.3.1 Create smithery.yaml
-- [ ] 5.3.2 Submit to smithery.ai
+- [ ] 5.3.1 Create `smithery.yaml` and submit to [smithery.ai](https://smithery.ai)
+- [ ] 5.3.2 Submit to the [Official MCP Registry](https://registry.modelcontextprotocol.io):
+  - Build publisher CLI: `make publisher`
+  - Authenticate via GitHub OAuth
+  - Publish as `io.github.JuanCF/scrcpy-mcp`
 
-**Phase 5 Milestone:** Published on npm, installable via `npx scrcpy-mcp`.
+**Phase 5 Milestone:** Published on npm, installable via `npx scrcpy-mcp`, listed on Smithery and the official MCP Registry.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [
     "mcp",
@@ -14,7 +15,11 @@
     "mobile",
     "screen-control"
   ],
-  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JuanCF/scrcpy-mcp.git"
+  },
+  "author": "Juan C. Flores",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.JuanCF/scrcpy-mcp",
+  "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
+  "repository": {
+    "url": "https://github.com/JuanCF/scrcpy-mcp",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "scrcpy-mcp",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "ANDROID_SERIAL",
+          "description": "Target device serial number (from `adb devices`). Required when multiple devices are connected.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "ADB_PATH",
+          "description": "Custom path to the adb binary. Defaults to 'adb' on PATH.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "SCRCPY_SERVER_PATH",
+          "description": "Path to the scrcpy-server.jar file. Only needed if not installed in a standard location.",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,37 @@
+# Smithery configuration file: https://smithery.ai/docs/build/project-config/smithery-yaml
+#
+# NOTE: scrcpy-mcp requires a physical Android device connected via ADB.
+# It cannot be cloud-hosted and must run locally on the machine where
+# the device is connected.
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    properties:
+      androidSerial:
+        type: string
+        description: >
+          Target device serial number (from `adb devices`). Required when
+          multiple devices are connected. Equivalent to ANDROID_SERIAL env var.
+      adbPath:
+        type: string
+        description: >
+          Custom path to the adb binary. Defaults to 'adb' on PATH.
+          Equivalent to ADB_PATH env var.
+      scrcpyServerPath:
+        type: string
+        description: >
+          Path to the scrcpy-server.jar file. Only needed if scrcpy-server is
+          not installed in a standard location. Equivalent to SCRCPY_SERVER_PATH env var.
+
+commandFunction: |-
+  (config) => ({
+    command: 'node',
+    args: ['./dist/index.js'],
+    env: {
+      ...(config.androidSerial ? { ANDROID_SERIAL: config.androidSerial } : {}),
+      ...(config.adbPath ? { ADB_PATH: config.adbPath } : {}),
+      ...(config.scrcpyServerPath ? { SCRCPY_SERVER_PATH: config.scrcpyServerPath } : {}),
+    }
+  })


### PR DESCRIPTION
…gistry

- Add smithery.yaml for Smithery submission
- Add server.json for official MCP Registry
- Add mcpName, repository, and author fields to package.json
- Automate MCP Registry publishing in CI workflow via GitHub OIDC
- Update ROADMAP.md with registry listing tasks
- Bump version to 0.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now publishes to the MCP Registry in addition to npm.
  * Added registry manifest and Smithery configuration to enable registry listing and runtime config.

* **Chores**
  * Version bumped to 0.1.1 and project metadata (author, repository, mcp name) updated.

* **Documentation**
  * Roadmap updated to reflect registry-focused publishing steps and listing tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->