### PR TITLE
fix(ci): restore registry-url and add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -40,6 +41,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Publish
         if: steps.version_check.outputs.changed == 'true'
-        run: npm publish --provenance --access public
+        run: npm publish --access public
 
       - name: Install mcp-publisher
         if: steps.version_check.outputs.changed == 'true'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/JuanCF/scrcpy-mcp",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "scrcpy-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
- Add back registry-url per npm trusted publishing docs
- Add workflow_dispatch to allow manual runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual trigger for releases to allow on-demand workflow runs.
  * Configured the npm registry and adjusted publish settings to ensure packages remain publicly accessible.
  * Bumped package and server metadata versions from 0.1.2 to 0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->