### PR TITLE
feat: label-based releases, Smithery publish support, contribution guide

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,34 +1,73 @@
 name: Publish
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Version tag to publish (e.g. 0.1.3)'
-        required: false
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 permissions:
-  contents: read
+  contents: write
   id-token: write
 jobs:
   publish:
+    # Run on merge only when a release label is present, or when triggered manually
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.merged == true &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'patch') ||
+          contains(github.event.pull_request.labels.*.name, 'minor') ||
+          contains(github.event.pull_request.labels.*.name, 'major')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Extract version from tag
+        with:
+          ref: main
+      - name: Determine bump type
+        id: bump
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "type=${{ github.event.inputs.bump }}" >> $GITHUB_OUTPUT
+          else
+            LABELS='${{ join(github.event.pull_request.labels.*.name, ' ') }}'
+            if echo "$LABELS" | grep -qw "major"; then
+              echo "type=major" >> $GITHUB_OUTPUT
+            elif echo "$LABELS" | grep -qw "minor"; then
+              echo "type=minor" >> $GITHUB_OUTPUT
+            else
+              echo "type=patch" >> $GITHUB_OUTPUT
+            fi
+          fi
+      - name: Bump version in package.json
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            VERSION="${{ github.event.inputs.tag }}"
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            echo "No valid tag provided. Supply a tag via workflow_dispatch or push a v* tag."
-            exit 1
-          fi
+          npm version ${{ steps.bump.outputs.type }} --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Commit, tag, and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${{ steps.version.outputs.version }}"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin main
+          git push origin "v${{ steps.version.outputs.version }}"
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -38,13 +77,6 @@ jobs:
         run: npm install -g npm@latest
       - name: Install dependencies
         run: npm ci
-      - name: Verify package.json version matches tag
-        run: |
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          if [ "$PKG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "Tag version and package.json version do not match"
-            exit 1
-          fi
       - name: Publish to npm (Trusted Publishing)
         run: npm publish --access public --provenance
       # -----------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.smithery/
 dist/
 .env
 .env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Development
+
+```bash
+npm install
+npm run build   # compile TypeScript → dist/
+npx vitest      # run tests
+```
+
+## Pull Requests
+
+Open PRs against `main`. Keep changes focused — one concern per PR.
+
+## Releasing
+
+Releases are triggered automatically when a PR is merged into `main` with one of these labels:
+
+| Label   | When to use |
+|---------|-------------|
+| `patch` | Bug fixes, small improvements (e.g. `1.2.3` → `1.2.4`) |
+| `minor` | New backwards-compatible features (e.g. `1.2.3` → `1.3.0`) |
+| `major` | Breaking changes (e.g. `1.2.3` → `2.0.0`) |
+
+**PRs without a release label are not published.** Use this for docs, CI changes, refactors, or anything that shouldn't trigger a release.
+
+When a labeled PR merges, the workflow will:
+
+1. Bump the version in `package.json` according to the label
+2. Commit the version bump to `main`
+3. Create and push a git tag (e.g. `v1.2.4`)
+4. Publish to npm
+5. Publish to the MCP Registry
+
+### Emergency / manual release
+
+If you need to trigger a publish outside of a PR merge, go to **Actions → Publish → Run workflow** and select the bump type.
+
+## Publishing to Smithery
+
+After a new version is released to npm, update the Smithery listing:
+
+```bash
+npm run publish:smithery
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ When a labeled PR merges, the workflow will:
 
 ### Emergency / manual release
 
-If you need to trigger a publish outside of a PR merge, go to **Actions → Publish → Run workflow** and select the bump type.
+If you need to trigger a publish outside a PR merge, go to **Actions → Publish → Run workflow** and select the bump type.
 
 ## Publishing to Smithery
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepublishOnly": "npm run build",
-    "publish:smithery": "smithery mcp publish https://github.com/JuanCF/scrcpy-mcp -n @JuanCF/scrcpy-mcp"
+    "publish:smithery": "npx smithery@4.1.1 mcp publish https://github.com/JuanCF/scrcpy-mcp -n @JuanCF/scrcpy-mcp"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "test": "vitest run",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "publish:smithery": "smithery mcp publish https://github.com/JuanCF/scrcpy-mcp -n @JuanCF/scrcpy-mcp"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,22 +12,32 @@ import { registerUiTools } from "./tools/ui.js"
 import { registerShellTools } from "./tools/shell.js"
 import { registerFileTools } from "./tools/files.js"
 
-const server = new McpServer({
-  name: "scrcpy-mcp",
-  version: "0.1.0",
-})
+function createServer() {
+  const server = new McpServer({
+    name: "scrcpy-mcp",
+    version: "0.1.0",
+  })
 
-registerSessionTools(server)
-registerDeviceTools(server)
-registerVisionTools(server)
-registerInputTools(server)
-registerAppTools(server)
-registerClipboardTools(server)
-registerUiTools(server)
-registerShellTools(server)
-registerFileTools(server)
+  registerSessionTools(server)
+  registerDeviceTools(server)
+  registerVisionTools(server)
+  registerInputTools(server)
+  registerAppTools(server)
+  registerClipboardTools(server)
+  registerUiTools(server)
+  registerShellTools(server)
+  registerFileTools(server)
+
+  return server
+}
+
+// Required by Smithery to scan tools without a live device
+export function createSandboxServer() {
+  return createServer()
+}
 
 async function main() {
+  const server = createServer()
   const transport = new StdioServerTransport()
   await server.connect(transport)
   console.error("[scrcpy-mcp] Server running on stdio")

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { registerFileTools } from "./tools/files.js"
 function createServer() {
   const server = new McpServer({
     name: "scrcpy-mcp",
-    version: "0.1.0",
+    version: process.env.npm_package_version ?? "0.0.0",
   })
 
   registerSessionTools(server)
@@ -31,7 +31,6 @@ function createServer() {
   return server
 }
 
-// Required by Smithery to scan tools without a live device
 export function createSandboxServer() {
   return createServer()
 }


### PR DESCRIPTION
- Replace tag-push publish trigger with PR label-based releases (patch/minor/major)
- Auto-bump version, commit, tag, and publish on merge when label is present
- Add createSandboxServer export for Smithery tool scanning
- Add npm run publish:smithery script
- Add CONTRIBUTING.md documenting the release flow
- Add .smithery/ to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated release workflow: version bumping and publishing can be triggered by PR labels (patch/minor/major) on merge or manually via dispatch with bump selection
  * New sandbox server mode for testing tools without a live device
  * Added support for publishing to Smithery registry

* **Documentation**
  * Added CONTRIBUTING.md with setup, PR guidelines, and release process

* **Chores**
  * Updated ignore rules to exclude a new local directory; added a publish script to package configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->