### PR TITLE
fix: remove commit-back to main, require manual version bump in PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Check tag does not already exist
         run: |
+          set -euo pipefail
           if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
             echo "Tag v${{ steps.version.outputs.version }} already exists. Bump the version in package.json before merging a release PR."
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Check tag does not already exist
         run: |
           set -euo pipefail
-          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
+          REMOTE_OUTPUT=$(git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}")
+          if echo "$REMOTE_OUTPUT" | grep -q .; then
             echo "Tag v${{ steps.version.outputs.version }} already exists. Bump the version in package.json before merging a release PR."
             exit 1
           fi
@@ -74,7 +75,7 @@ jobs:
           rm "${TARBALL}" checksums.txt
       - name: Update server.json version
         run: |
-          VERSION=${{ steps.version.outputs.version }}
+          VERSION="${{ steps.version.outputs.version }}"
           jq --arg v "$VERSION" '.version = $v | .packages[].version = $v' server.json > server.tmp
           mv server.tmp server.json
       - name: Authenticate to MCP Registry (OIDC)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Check tag does not already exist
         run: |
           set -euo pipefail
-          if ! REMOTE_OUTPUT=$(git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}"); then
-            echo "Failed to query remote tags"
+          if ! REMOTE_OUTPUT=$(git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" 2>&1); then
+            echo "Failed to query remote tags: $REMOTE_OUTPUT"
             exit 1
           fi
           if echo "$REMOTE_OUTPUT" | grep -q .; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,16 +6,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 permissions:
   contents: write
   id-token: write
@@ -38,35 +28,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-      - name: Determine bump type
-        id: bump
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "type=${{ github.event.inputs.bump }}" >> $GITHUB_OUTPUT
-          else
-            LABELS='${{ join(github.event.pull_request.labels.*.name, ' ') }}'
-            if echo "$LABELS" | grep -qw "major"; then
-              echo "type=major" >> $GITHUB_OUTPUT
-            elif echo "$LABELS" | grep -qw "minor"; then
-              echo "type=minor" >> $GITHUB_OUTPUT
-            else
-              echo "type=patch" >> $GITHUB_OUTPUT
-            fi
-          fi
-      - name: Bump version in package.json
+      - name: Read version from package.json
         id: version
         run: |
-          npm version ${{ steps.bump.outputs.type }} --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Commit, tag, and push
+      - name: Check tag does not already exist
+        run: |
+          if git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}" | grep -q .; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists. Bump the version in package.json before merging a release PR."
+            exit 1
+          fi
+      - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to v${{ steps.version.outputs.version }}"
           git tag "v${{ steps.version.outputs.version }}"
-          git push origin main
           git push origin "v${{ steps.version.outputs.version }}"
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Check tag does not already exist
         run: |
           set -euo pipefail
-          REMOTE_OUTPUT=$(git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}")
+          if ! REMOTE_OUTPUT=$(git ls-remote --tags origin "refs/tags/v${{ steps.version.outputs.version }}"); then
+            echo "Failed to query remote tags"
+            exit 1
+          fi
           if echo "$REMOTE_OUTPUT" | grep -q .; then
             echo "Tag v${{ steps.version.outputs.version }} already exists. Bump the version in package.json before merging a release PR."
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
       - name: Read version from package.json
         id: version
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          if [ -z "$VERSION" ] || ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "Invalid or missing version in package.json: '$VERSION'"
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Check tag does not already exist
         run: |
@@ -50,11 +59,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,18 @@ Releases are triggered automatically when a PR is merged into `main` with one of
 
 **PRs without a release label are not published.** Use this for docs, CI changes, refactors, or anything that shouldn't trigger a release.
 
+Before merging a release PR, bump the version in `package.json` manually (e.g. `npm version patch --no-git-tag-version`). The workflow reads the version from `package.json` and will fail if the tag already exists.
+
 When a labeled PR merges, the workflow will:
 
-1. Bump the version in `package.json` according to the label
-2. Commit the version bump to `main`
-3. Create and push a git tag (e.g. `v1.2.4`)
-4. Publish to npm
-5. Publish to the MCP Registry
+1. Read the version from `package.json`
+2. Create and push a git tag (e.g. `v1.2.4`)
+3. Publish to npm
+4. Publish to the MCP Registry
 
 ### Emergency / manual release
 
-If you need to trigger a publish outside a PR merge, go to **Actions → Publish → Run workflow** and select the bump type.
+If you need to trigger a publish outside a PR merge, go to **Actions → Publish → Run workflow**.
 
 ## Publishing to Smithery
 


### PR DESCRIPTION
Workflow no longer pushes to main (blocked by branch protection). Developer bumps package.json version in the PR; on merge the workflow reads it, creates the tag, and publishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide: require manual package version bump before a release PR, explain the workflow reads the version and will fail if the tag already exists, and revise emergency/manual release instructions.

* **Chores**
  * Simplified release automation: removed automatic bump/commit steps; workflow now reads the version, performs a duplicate-tag safety check, and creates/pushes only the version tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->