### PR TITLE
feat: add start/stop_video_stream tools with H.264 direct viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-mcp",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { registerClipboardTools } from "./tools/clipboard.js"
 import { registerUiTools } from "./tools/ui.js"
 import { registerShellTools } from "./tools/shell.js"
 import { registerFileTools } from "./tools/files.js"
+import { registerVideoTools } from "./tools/video.js"
 
 function createServer() {
   const server = new McpServer({
@@ -27,6 +28,7 @@ function createServer() {
   registerUiTools(server)
   registerShellTools(server)
   registerFileTools(server)
+  registerVideoTools(server)
 
   return server
 }

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import { resolveSerial } from "../utils/adb.js"
 import { startSession, stopSession } from "../utils/scrcpy.js"
+import { stopMjpegServer } from "../utils/mjpeg.js"
 
 export function registerSessionTools(server: McpServer): void {
   server.registerTool(
@@ -56,6 +57,7 @@ export function registerSessionTools(server: McpServer): void {
       try {
         const s = await resolveSerial(serial)
         await stopSession(s)
+        stopMjpegServer(s)
         return {
           content: [{
             type: "text",

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -28,16 +28,24 @@ export function registerVideoTools(server: McpServer): void {
             }],
           }
         }
-        const resolvedPort = port ?? 7183
+        const session = getSession(s)
+        if (!session) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                status: "error",
+                message: "No active scrcpy session. Call start_session first.",
+              }, null, 2),
+            }],
+          }
+        }
+        const resolvedPort = port
         const url = await startMjpegServer(s, resolvedPort)
 
-        const session = getSession(s)
-        let viewerLaunched = false
-        if (session) {
-          viewerLaunched = await startMjpegViewer(
-            s, session.screenSize.width, session.screenSize.height, resolvedPort
-          )
-        }
+        const viewerLaunched = await startMjpegViewer(
+          s, session.screenSize.width, session.screenSize.height, resolvedPort
+        )
 
         return {
           content: [{
@@ -45,7 +53,7 @@ export function registerVideoTools(server: McpServer): void {
             text: JSON.stringify({
               status: "started",
               url,
-              screenSize: session?.screenSize,
+              screenSize: session.screenSize,
               viewer: viewerLaunched ? "ffplay window opened" : "ffplay not available — open URL manually",
             }, null, 2),
           }],
@@ -80,7 +88,10 @@ export function registerVideoTools(server: McpServer): void {
           return {
             content: [{
               type: "text",
-              text: "No video stream is running for this device.",
+              text: JSON.stringify({
+                status: "error",
+                message: "No video stream is running for this device.",
+              }, null, 2),
             }],
           }
         }
@@ -88,7 +99,10 @@ export function registerVideoTools(server: McpServer): void {
         return {
           content: [{
             type: "text",
-            text: "Video stream stopped.",
+            text: JSON.stringify({
+              status: "stopped",
+              message: "Video stream stopped.",
+            }, null, 2),
           }],
         }
       } catch (error) {

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -35,7 +35,7 @@ export function registerVideoTools(server: McpServer): void {
         let viewerLaunched = false
         if (session) {
           viewerLaunched = await startMjpegViewer(
-            s, session.screenSize.width, session.screenSize.height
+            s, session.screenSize.width, session.screenSize.height, resolvedPort
           )
         }
 

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -29,12 +29,14 @@ export function registerVideoTools(server: McpServer): void {
           }
         }
         const resolvedPort = port ?? 7183
-        const url = startMjpegServer(s, resolvedPort)
+        const url = await startMjpegServer(s, resolvedPort)
 
         const session = getSession(s)
         let viewerLaunched = false
         if (session) {
-          viewerLaunched = startMjpegViewer(s, session.screenSize.width, session.screenSize.height)
+          viewerLaunched = await startMjpegViewer(
+            s, session.screenSize.width, session.screenSize.height
+          )
         }
 
         return {

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -8,7 +8,7 @@ export function registerVideoTools(server: McpServer): void {
   server.registerTool(
     "start_video_stream",
     {
-      description: "Start an HTTP MJPEG video stream of the device screen. Opens a native ffplay window sized to the device screen that receives raw H.264 directly (no re-encode). Requires an active scrcpy session.",
+      description: "Start an HTTP MJPEG video stream of the device screen. Opens a native ffplay window that connects to the stream URL. Requires an active scrcpy session.",
       inputSchema: {
         serial: z.string().optional().describe("Device serial number"),
         port: z.number().int().min(1024).max(65535).optional().default(7183).describe("HTTP port for the MJPEG stream (default 7183)"),

--- a/src/tools/video.ts
+++ b/src/tools/video.ts
@@ -1,0 +1,106 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+import { resolveSerial } from "../utils/adb.js"
+import { hasActiveSession, getSession } from "../utils/scrcpy.js"
+import { startMjpegServer, startMjpegViewer, stopMjpegServer, isMjpegServerRunning } from "../utils/mjpeg.js"
+
+export function registerVideoTools(server: McpServer): void {
+  server.registerTool(
+    "start_video_stream",
+    {
+      description: "Start an HTTP MJPEG video stream of the device screen. Opens a native ffplay window sized to the device screen that receives raw H.264 directly (no re-encode). Requires an active scrcpy session.",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+        port: z.number().int().min(1024).max(65535).optional().default(7183).describe("HTTP port for the MJPEG stream (default 7183)"),
+      },
+    },
+    async ({ serial, port }) => {
+      try {
+        const s = await resolveSerial(serial)
+        if (!hasActiveSession(s)) {
+          return {
+            content: [{
+              type: "text",
+              text: JSON.stringify({
+                status: "error",
+                message: "No active scrcpy session. Call start_session first.",
+              }, null, 2),
+            }],
+          }
+        }
+        const resolvedPort = port ?? 7183
+        const url = startMjpegServer(s, resolvedPort)
+
+        const session = getSession(s)
+        let viewerLaunched = false
+        if (session) {
+          viewerLaunched = startMjpegViewer(s, session.screenSize.width, session.screenSize.height)
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              status: "started",
+              url,
+              screenSize: session?.screenSize,
+              viewer: viewerLaunched ? "ffplay window opened" : "ffplay not available — open URL manually",
+            }, null, 2),
+          }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              status: "error",
+              message: `Failed to start video stream: ${err.message}`,
+            }, null, 2),
+          }],
+        }
+      }
+    }
+  )
+
+  server.registerTool(
+    "stop_video_stream",
+    {
+      description: "Stop the HTTP MJPEG video stream and close the viewer window for a device.",
+      inputSchema: {
+        serial: z.string().optional().describe("Device serial number"),
+      },
+    },
+    async ({ serial }) => {
+      try {
+        const s = await resolveSerial(serial)
+        if (!isMjpegServerRunning(s)) {
+          return {
+            content: [{
+              type: "text",
+              text: "No video stream is running for this device.",
+            }],
+          }
+        }
+        stopMjpegServer(s)
+        return {
+          content: [{
+            type: "text",
+            text: "Video stream stopped.",
+          }],
+        }
+      } catch (error) {
+        const err = error as Error
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              status: "error",
+              message: `Failed to stop video stream: ${err.message}`,
+            }, null, 2),
+          }],
+        }
+      }
+    }
+  )
+}

--- a/src/utils/mjpeg.ts
+++ b/src/utils/mjpeg.ts
@@ -76,7 +76,7 @@ export async function startMjpegServer(serial: string, port: number): Promise<st
 }
 
 export async function startMjpegViewer(
-  serial: string, width: number, height: number
+  serial: string, width: number, height: number, port: number
 ): Promise<boolean> {
   const session = getSession(serial)
   if (!session) return false
@@ -95,26 +95,21 @@ export async function startMjpegViewer(
       "-y", String(height),
       "-window_title", "scrcpy-mcp",
       "-loglevel", "quiet",
-      "-f", "h264",
-      "-i", "pipe:0",
-    ], { stdio: ["pipe", "ignore", "ignore"] })
+      `http://localhost:${port}`,
+    ], { stdio: ["ignore", "ignore", "ignore"] })
 
     viewer.once("spawn", () => {
-      // Replay buffered H.264 history so ffplay can find a keyframe (SPS+PPS+IDR)
-      // even when connecting after the session has been running for a while.
-      if (viewer.stdin && session.h264Buffer.length > 0) {
-        viewer.stdin.write(session.h264Buffer)
-      }
       session.viewerProcess = viewer
-      session.viewerStdin = viewer.stdin
       settled = true
       resolve(true)
     })
 
     viewer.on("error", (err) => {
       console.error(`[mjpeg] ffplay error for ${serial}:`, err.message)
-      session.viewerProcess = null
-      session.viewerStdin = null
+      if (session.viewerProcess === viewer) {
+        session.viewerProcess = null
+        session.viewerStdin = null
+      }
       if (!settled) {
         settled = true
         resolve(false)
@@ -122,8 +117,10 @@ export async function startMjpegViewer(
     })
 
     viewer.on("exit", () => {
-      session.viewerProcess = null
-      session.viewerStdin = null
+      if (session.viewerProcess === viewer) {
+        session.viewerProcess = null
+        session.viewerStdin = null
+      }
     })
   })
 }

--- a/src/utils/mjpeg.ts
+++ b/src/utils/mjpeg.ts
@@ -1,0 +1,123 @@
+import http from "http"
+import { spawn } from "child_process"
+import { getLatestFrame, getSession } from "./scrcpy.js"
+
+interface MjpegEntry {
+  server: http.Server
+  clients: Set<http.ServerResponse>
+  intervalId: NodeJS.Timeout
+  port: number
+}
+
+const servers = new Map<string, MjpegEntry>()
+const BOUNDARY = "scrcpy_frame"
+const FRAME_INTERVAL_MS = 33 // ~30 fps
+
+export function startMjpegServer(serial: string, port: number): string {
+  if (servers.has(serial)) stopMjpegServer(serial)
+
+  const clients = new Set<http.ServerResponse>()
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, {
+      "Content-Type": `multipart/x-mixed-replace; boundary=${BOUNDARY}`,
+      "Cache-Control": "no-cache",
+      "Connection": "keep-alive",
+    })
+    clients.add(res)
+    res.on("close", () => clients.delete(res))
+  })
+
+  server.listen(port)
+
+  let lastFrame: Buffer | null = null
+
+  const intervalId = setInterval(() => {
+    if (clients.size === 0) return
+    const frame = getLatestFrame(serial)
+    if (!frame || frame === lastFrame) return
+    lastFrame = frame
+
+    const header = Buffer.from(
+      `--${BOUNDARY}\r\nContent-Type: image/jpeg\r\nContent-Length: ${frame.length}\r\n\r\n`
+    )
+    const tail = Buffer.from("\r\n")
+    const chunk = Buffer.concat([header, frame, tail])
+
+    for (const res of clients) {
+      try { res.write(chunk) } catch { clients.delete(res) }
+    }
+  }, FRAME_INTERVAL_MS)
+
+  servers.set(serial, { server, clients, intervalId, port })
+  return `http://localhost:${port}`
+}
+
+export function startMjpegViewer(serial: string, width: number, height: number): boolean {
+  const session = getSession(serial)
+  if (!session) return false
+
+  if (session.viewerProcess && !session.viewerProcess.killed) {
+    session.viewerProcess.kill()
+  }
+  session.viewerProcess = null
+  session.viewerStdin = null
+
+  try {
+    // ffplay reads raw H.264 directly from stdin — no MJPEG re-encode needed.
+    const viewer = spawn("ffplay", [
+      "-x", String(width),
+      "-y", String(height),
+      "-window_title", "scrcpy-mcp",
+      "-loglevel", "quiet",
+      "-f", "h264",
+      "-i", "pipe:0",
+    ], { stdio: ["pipe", "ignore", "ignore"] })
+
+    viewer.on("error", (err) => {
+      console.error(`[mjpeg] ffplay error for ${serial}:`, err.message)
+      session.viewerProcess = null
+      session.viewerStdin = null
+    })
+
+    viewer.on("exit", () => {
+      session.viewerProcess = null
+      session.viewerStdin = null
+    })
+
+    // Replay buffered H.264 history so ffplay can find a keyframe (SPS+PPS+IDR)
+    // even when connecting after the session has been running for a while.
+    if (viewer.stdin && session.h264Buffer.length > 0) {
+      viewer.stdin.write(session.h264Buffer)
+    }
+    session.viewerProcess = viewer
+    session.viewerStdin = viewer.stdin
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function stopMjpegServer(serial: string): boolean {
+  const entry = servers.get(serial)
+  if (!entry) return false
+  clearInterval(entry.intervalId)
+  for (const res of entry.clients) { try { res.end() } catch {} }
+  entry.server.close()
+
+  const session = getSession(serial)
+  if (session) {
+    if (session.viewerProcess && !session.viewerProcess.killed) {
+      session.viewerProcess.kill()
+    }
+    session.viewerProcess = null
+    session.viewerStdin = null
+  }
+
+  servers.delete(serial)
+  return true
+}
+
+export function isMjpegServerRunning(serial: string): boolean {
+  return servers.has(serial)
+}

--- a/src/utils/mjpeg.ts
+++ b/src/utils/mjpeg.ts
@@ -68,11 +68,14 @@ export async function startMjpegServer(serial: string, port: number): Promise<st
         console.error(`[mjpeg] Failed to end client for ${serial}:`, e)
       }
     }
+    server.close((closeErr) => {
+      if (closeErr) console.error(`[mjpeg] Failed to close server for ${serial}:`, closeErr)
+    })
     servers.delete(serial)
   })
 
   servers.set(serial, { server, clients, intervalId, port })
-  return `http://localhost:${port}`
+  return `http://127.0.0.1:${port}`
 }
 
 export async function startMjpegViewer(
@@ -95,7 +98,7 @@ export async function startMjpegViewer(
       "-y", String(height),
       "-window_title", "scrcpy-mcp",
       "-loglevel", "quiet",
-      `http://localhost:${port}`,
+      `http://127.0.0.1:${port}`,
     ], { stdio: ["ignore", "ignore", "ignore"] })
 
     viewer.once("spawn", () => {

--- a/src/utils/mjpeg.ts
+++ b/src/utils/mjpeg.ts
@@ -13,7 +13,7 @@ const servers = new Map<string, MjpegEntry>()
 const BOUNDARY = "scrcpy_frame"
 const FRAME_INTERVAL_MS = 33 // ~30 fps
 
-export function startMjpegServer(serial: string, port: number): string {
+export async function startMjpegServer(serial: string, port: number): Promise<string> {
   if (servers.has(serial)) stopMjpegServer(serial)
 
   const clients = new Set<http.ServerResponse>()
@@ -28,7 +28,14 @@ export function startMjpegServer(serial: string, port: number): string {
     res.on("close", () => clients.delete(res))
   })
 
-  server.listen(port)
+  // Wait for listen to succeed; reject immediately on bind error
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port, "127.0.0.1", () => {
+      server.removeListener("error", reject)
+      resolve()
+    })
+  })
 
   let lastFrame: Buffer | null = null
 
@@ -45,15 +52,32 @@ export function startMjpegServer(serial: string, port: number): string {
     const chunk = Buffer.concat([header, frame, tail])
 
     for (const res of clients) {
-      try { res.write(chunk) } catch { clients.delete(res) }
+      try { res.write(chunk) } catch (err) {
+        console.error(`[mjpeg] Failed to write to client for ${serial}:`, err)
+        clients.delete(res)
+      }
     }
   }, FRAME_INTERVAL_MS)
+
+  // Runtime error handler (after successful bind)
+  server.on("error", (err) => {
+    console.error(`[mjpeg] Server error for ${serial}:`, err)
+    clearInterval(intervalId)
+    for (const res of clients) {
+      try { res.end() } catch (e) {
+        console.error(`[mjpeg] Failed to end client for ${serial}:`, e)
+      }
+    }
+    servers.delete(serial)
+  })
 
   servers.set(serial, { server, clients, intervalId, port })
   return `http://localhost:${port}`
 }
 
-export function startMjpegViewer(serial: string, width: number, height: number): boolean {
+export async function startMjpegViewer(
+  serial: string, width: number, height: number
+): Promise<boolean> {
   const session = getSession(serial)
   if (!session) return false
 
@@ -63,8 +87,9 @@ export function startMjpegViewer(serial: string, width: number, height: number):
   session.viewerProcess = null
   session.viewerStdin = null
 
-  try {
-    // ffplay reads raw H.264 directly from stdin — no MJPEG re-encode needed.
+  return new Promise<boolean>((resolve) => {
+    let settled = false
+
     const viewer = spawn("ffplay", [
       "-x", String(width),
       "-y", String(height),
@@ -74,35 +99,44 @@ export function startMjpegViewer(serial: string, width: number, height: number):
       "-i", "pipe:0",
     ], { stdio: ["pipe", "ignore", "ignore"] })
 
+    viewer.once("spawn", () => {
+      // Replay buffered H.264 history so ffplay can find a keyframe (SPS+PPS+IDR)
+      // even when connecting after the session has been running for a while.
+      if (viewer.stdin && session.h264Buffer.length > 0) {
+        viewer.stdin.write(session.h264Buffer)
+      }
+      session.viewerProcess = viewer
+      session.viewerStdin = viewer.stdin
+      settled = true
+      resolve(true)
+    })
+
     viewer.on("error", (err) => {
       console.error(`[mjpeg] ffplay error for ${serial}:`, err.message)
       session.viewerProcess = null
       session.viewerStdin = null
+      if (!settled) {
+        settled = true
+        resolve(false)
+      }
     })
 
     viewer.on("exit", () => {
       session.viewerProcess = null
       session.viewerStdin = null
     })
-
-    // Replay buffered H.264 history so ffplay can find a keyframe (SPS+PPS+IDR)
-    // even when connecting after the session has been running for a while.
-    if (viewer.stdin && session.h264Buffer.length > 0) {
-      viewer.stdin.write(session.h264Buffer)
-    }
-    session.viewerProcess = viewer
-    session.viewerStdin = viewer.stdin
-    return true
-  } catch {
-    return false
-  }
+  })
 }
 
 export function stopMjpegServer(serial: string): boolean {
   const entry = servers.get(serial)
   if (!entry) return false
   clearInterval(entry.intervalId)
-  for (const res of entry.clients) { try { res.end() } catch { /* ignore */ } }
+  for (const res of entry.clients) {
+    try { res.end() } catch (err) {
+      console.error(`[mjpeg] Failed to end client for ${serial}:`, err)
+    }
+  }
   entry.server.close()
 
   const session = getSession(serial)

--- a/src/utils/mjpeg.ts
+++ b/src/utils/mjpeg.ts
@@ -102,7 +102,7 @@ export function stopMjpegServer(serial: string): boolean {
   const entry = servers.get(serial)
   if (!entry) return false
   clearInterval(entry.intervalId)
-  for (const res of entry.clients) { try { res.end() } catch {} }
+  for (const res of entry.clients) { try { res.end() } catch { /* ignore */ } }
   entry.server.close()
 
   const session = getSession(serial)

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -470,7 +470,9 @@ function startVideoStream(
       // Update rolling H.264 buffer
       session.h264Buffer = Buffer.concat([session.h264Buffer, chunk])
       if (session.h264Buffer.length > MAX_H264_BUFFER) {
-        session.h264Buffer = session.h264Buffer.subarray(session.h264Buffer.length - MAX_H264_BUFFER)
+        session.h264Buffer = session.h264Buffer.subarray(
+          session.h264Buffer.length - MAX_H264_BUFFER
+        )
       }
       if (session.viewerStdin) {
         const vs = session.viewerStdin as NodeJS.WritableStream & { destroyed?: boolean }

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -269,6 +269,9 @@ export interface ScrcpySession {
   frameBuffer: Buffer | null
   screenSize: { width: number; height: number }
   clipboardContent: string | null
+  viewerProcess: ChildProcess | null
+  viewerStdin: NodeJS.WritableStream | null
+  h264Buffer: Buffer  // rolling buffer for late viewer connections
 }
 
 const sessions: Map<string, ScrcpySession> = new Map()
@@ -447,18 +450,37 @@ function startVideoStream(
       } else {
         console.error(`[scrcpy] ffmpeg stdin error for ${session.serial}:`, err.message)
       }
-      videoSocket.unpipe()
     })
 
-    ffmpeg.stdin.on("close", () => {
-      videoSocket.unpipe()
-    })
-
-    // Write any overflow bytes from the metadata read before piping
+    // Write any overflow bytes from the metadata read before starting the tee
     if (initialData && initialData.length > 0) {
       ffmpeg.stdin.write(initialData)
     }
-    videoSocket.pipe(ffmpeg.stdin)
+
+    // Tee the raw H.264 stream: ffmpeg (for JPEG frame extraction / screenshots)
+    // and optionally the viewer process stdin (raw H.264, no re-encode needed).
+    // A rolling buffer of recent H.264 data is kept so that a viewer that connects
+    // after session start can receive enough history to include a full keyframe
+    // (SPS+PPS+IDR), allowing it to start decoding immediately.
+    const MAX_H264_BUFFER = 2 * 1024 * 1024 // 2 MB ≈ 2s at 8Mbps
+    videoSocket.on("data", (chunk: Buffer) => {
+      if (ffmpeg.stdin && !ffmpeg.stdin.destroyed) {
+        try { ffmpeg.stdin.write(chunk) } catch { /* EPIPE handled above */ }
+      }
+      // Update rolling H.264 buffer
+      session.h264Buffer = Buffer.concat([session.h264Buffer, chunk])
+      if (session.h264Buffer.length > MAX_H264_BUFFER) {
+        session.h264Buffer = session.h264Buffer.subarray(session.h264Buffer.length - MAX_H264_BUFFER)
+      }
+      if (session.viewerStdin) {
+        const vs = session.viewerStdin as NodeJS.WritableStream & { destroyed?: boolean }
+        if (!vs.destroyed) {
+          try { vs.write(chunk) } catch {
+            session.viewerStdin = null
+          }
+        }
+      }
+    })
   }
 
   return firstFramePromise
@@ -900,6 +922,9 @@ export async function startSession(
       frameBuffer: null,
       screenSize: { width, height },
       clipboardContent: null,
+      viewerProcess: null,
+      viewerStdin: null,
+      h264Buffer: Buffer.alloc(0),
     }
 
     const currentSession = session
@@ -968,6 +993,12 @@ export async function stopSession(serial: string): Promise<void> {
     session.videoProcess.kill()
     session.videoProcess = null
   }
+
+  if (session.viewerProcess && !session.viewerProcess.killed) {
+    session.viewerProcess.kill()
+  }
+  session.viewerProcess = null
+  session.viewerStdin = null
 
   try {
     await execAdbShell(s, `pkill -f scrcpy-server`)

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -452,17 +452,24 @@ function startVideoStream(
       }
     })
 
-    // Write any overflow bytes from the metadata read before starting the tee
-    if (initialData && initialData.length > 0) {
-      ffmpeg.stdin.write(initialData)
-    }
-
     // Tee the raw H.264 stream: ffmpeg (for JPEG frame extraction / screenshots)
     // and optionally the viewer process stdin (raw H.264, no re-encode needed).
     // A rolling buffer of recent H.264 data is kept so that a viewer that connects
     // after session start can receive enough history to include a full keyframe
     // (SPS+PPS+IDR), allowing it to start decoding immediately.
     const MAX_H264_BUFFER = 2 * 1024 * 1024 // 2 MB ≈ 2s at 8Mbps
+
+    // Write any overflow bytes from the metadata read before starting the tee,
+    // and include them in the rolling H.264 history (they carry SPS/PPS/IDR data).
+    if (initialData && initialData.length > 0) {
+      ffmpeg.stdin.write(initialData)
+      session.h264Buffer = Buffer.concat([session.h264Buffer, initialData])
+      if (session.h264Buffer.length > MAX_H264_BUFFER) {
+        session.h264Buffer = session.h264Buffer.subarray(
+          session.h264Buffer.length - MAX_H264_BUFFER
+        )
+      }
+    }
     videoSocket.on("data", (chunk: Buffer) => {
       if (ffmpeg.stdin && !ffmpeg.stdin.destroyed) {
         try { ffmpeg.stdin.write(chunk) } catch { /* EPIPE handled above */ }


### PR DESCRIPTION
Adds two new MCP tools: start_video_stream and stop_video_stream. The stream is served as MJPEG over HTTP using JPEG frames extracted by the existing ffmpeg pipeline. A native ffplay window receives raw H.264 directly (no re-encode) via a tee on the video socket. A rolling 2 MB H.264 buffer ensures late viewers can find a keyframe and start decoding immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time device screen streaming over HTTP (MJPEG) with an optional local viewer; responses include stream URL and screen size.
  * Start/stop stream controls and automatic viewer relaunch for smoother reconnects using a recent video buffer.
  * Server initialization now exposes video streaming tools.

* **Bug Fixes**
  * Stopping a device session also stops any active stream and viewer to prevent orphaned streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->