### PR TITLE
ci: update mcp-publisher to v1.7.9 to fix OIDC audience mismatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
       # -----------------------------
       - name: Install mcp-publisher
         run: |
-          MCP_VERSION="v1.4.1"
+          MCP_VERSION="v1.7.9"
           VERSION_NUM="${MCP_VERSION#v}"
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')


### PR DESCRIPTION
The MCP Registry publish step was failing with 401: 'invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]'

Updating from v1.4.1 to v1.7.9 resolves the OIDC token exchange issue.