### PR TITLE
ci: update mcp-publisher to v1.7.9 to fix OIDC audience mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/JuanCF/scrcpy-mcp",
     "source": "github"
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "scrcpy-mcp",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The MCP Registry publish step was failing with 401: 'invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]'

Updating from v1.4.1 to v1.7.9 resolves the OIDC token exchange issue.