### PR TITLE
chore: add MCP bundle packaging config and scripts

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,41 @@
+# Dev source (dist/ is what runs, not src/)
+src/
+tests/
+
+# Config/tooling files
+.claude/
+.github/
+.opencode/
+.coderabbit.yaml
+.npmrc
+.nvmrc
+eslint.config.js
+tsconfig.json
+tsup.config.ts
+vitest.config.ts
+vitest.integration.config.ts
+opencode.json
+.mcp.json
+smithery.yaml
+
+# Docs
+AGENTS.md
+CONTRIBUTING.md
+PLAN.md
+ROADMAP.md
+
+# Build artifacts
+*.mcpb
+package-lock.json
+
+# Heavy node_modules junk
+node_modules/**/*.md
+node_modules/**/*.ts
+node_modules/**/*.map
+node_modules/**/test/
+node_modules/**/tests/
+node_modules/**/__tests__/
+node_modules/**/docs/
+node_modules/**/examples/
+node_modules/ffmpeg-static/bin/
+node_modules/ffmpeg-static/*.exe

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "pack:bundle": "rm -rf node_modules && npm ci --omit=dev --omit=optional && mcpb pack",
+    "pack:publish": "smithery mcp publish ./scrcpy-mcp.mcpb -n JuanCF/scrcpy-mcp"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Add .mcpbignore to exclude source, tests, config, docs, and heavy node_modules content from the MCP bundle, keeping only the dist/ output and production dependencies. Add npm scripts pack:bundle (clean install + mcpb pack) and pack:publish (smithery publish) to streamline distribution of the server as a self-contained .mcpb bundle on Smithery.