### PR TITLE
feat: add scrcpy 4.x compatibility and version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ If you need to configure custom options (such as pointing to a non-standard `scr
 
 *Note: On Windows, remember to double-escape backslashes (`\\`) in your configuration paths.*
 
+> **OpenCode users:** OpenCode uses `"environment"` instead of `"env"` for passing environment variables to MCP servers. Replace `"env"` with `"environment"` in the example above if you're configuring scrcpy-mcp in `opencode.json`.
+
 ## Tool Reference
 
 ### Session Management

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,31 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -55,6 +80,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1526,7 +1552,6 @@
       "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1576,7 +1601,6 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -1894,7 +1918,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2386,7 +2409,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2447,7 +2469,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2676,7 +2697,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3021,7 +3041,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3865,7 +3884,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3924,7 +3942,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4639,7 +4656,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5194,7 +5210,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5282,7 +5297,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5521,7 +5535,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1036,6 +1036,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,31 +48,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -117,7 +117,7 @@ export function registerSessionTools(server: McpServer): void {
       inputSchema: {},
       outputSchema: {
         version: z.string().describe("Scrcpy version string (e.g. '4.0', '2.7')"),
-        source: z.string().describe("Where the version was resolved from: 'env' (SCRCPY_SERVER_VERSION env var), 'binary' (scrcpy --version), or 'default' (built-in constant)"),
+        source: z.enum(["env", "binary", "default"]).describe("Where the version was resolved from: 'env' (SCRCPY_SERVER_VERSION env var), 'binary' (scrcpy --version), or 'default' (built-in constant)"),
       },
       annotations: {
         title: "Scrcpy Version",

--- a/src/tools/session.ts
+++ b/src/tools/session.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import { resolveSerial } from "../utils/adb.js"
-import { startSession, stopSession } from "../utils/scrcpy.js"
+import { startSession, stopSession, detectScrcpyVersionInfo } from "../utils/scrcpy.js"
 import { stopMjpegServer } from "../utils/mjpeg.js"
 
 export function registerSessionTools(server: McpServer): void {
@@ -106,6 +106,30 @@ export function registerSessionTools(server: McpServer): void {
           }],
           isError: true as const,
         }
+      }
+    }
+  )
+
+  server.registerTool(
+    "version",
+    {
+      description: "Report which scrcpy version is being used by the MCP server. The version is detected from the SCRCPY_SERVER_VERSION environment variable, the scrcpy --version binary, or a built-in default.",
+      inputSchema: {},
+      outputSchema: {
+        version: z.string().describe("Scrcpy version string (e.g. '4.0', '2.7')"),
+        source: z.string().describe("Where the version was resolved from: 'env' (SCRCPY_SERVER_VERSION env var), 'binary' (scrcpy --version), or 'default' (built-in constant)"),
+      },
+      annotations: {
+        title: "Scrcpy Version",
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      const { version, source } = detectScrcpyVersionInfo()
+      return {
+        content: [{ type: "text", text: `${version} (source: ${source})` }],
+        structuredContent: { version, source },
       }
     }
   )

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -124,3 +124,17 @@ export const DEVICE_META_SIZE = 76
 export const DEVICE_NAME_OFFSET = 0
 export const VIDEO_WIDTH_OFFSET = 68
 export const VIDEO_HEIGHT_OFFSET = 72
+
+/*
+ * scrcpy 4.0 replaced send_codec_meta with send_stream_meta. Its header adds
+ * a 4-byte session-meta flags field between the codec ID and the dimensions:
+ *   Device name: 64 bytes (offset 0..63)
+ *   Codec ID:    4 bytes u32be (offset 64..67)
+ *   Flags:       4 bytes u32be (offset 68..71)
+ *   Width:       4 bytes u32be (offset 72..75)
+ *   Height:      4 bytes u32be (offset 76..79)
+ * Total after dummy byte: 80 bytes
+ */
+export const V4_DEVICE_META_SIZE = 80
+export const V4_VIDEO_WIDTH_OFFSET = 72
+export const V4_VIDEO_HEIGHT_OFFSET = 76

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -34,6 +34,9 @@ import {
   DEVICE_NAME_OFFSET,
   VIDEO_WIDTH_OFFSET,
   VIDEO_HEIGHT_OFFSET,
+  V4_DEVICE_META_SIZE,
+  V4_VIDEO_WIDTH_OFFSET,
+  V4_VIDEO_HEIGHT_OFFSET,
 } from "./constants.js"
 
 export function serializeInjectKeycode(
@@ -311,7 +314,14 @@ const findFfmpeg = (): string => {
     // download was skipped/failed, so verify the file actually exists before
     // returning it. Otherwise spawn fails with ENOENT and the video socket
     // teardown cascades into killing the whole scrcpy session.
-    if (ffmpegStatic && fs.existsSync(ffmpegStatic)) return ffmpegStatic
+    if (ffmpegStatic && fs.existsSync(ffmpegStatic)) {
+      try {
+        fs.accessSync(ffmpegStatic, fs.constants.X_OK)
+        return ffmpegStatic
+      } catch {
+        // file exists but is not executable, fall back to system ffmpeg
+      }
+    }
   } catch {
     // ffmpeg-static not installed, fall back to system ffmpeg
   }
@@ -517,14 +527,28 @@ export function findScrcpyServer(): string | null {
   return null
 }
 
+// Memoized: the version cannot change mid-process, and the uncached form runs
+// a blocking execSync per call. Caching also guarantees every caller in a
+// session start sees the same version, so the server launch args and the
+// client's protocol expectations can never disagree.
+let cachedScrcpyVersion: DetectedVersion | null = null
+
+export interface DetectedVersion {
+  version: string
+  // Where the version was resolved from: the SCRCPY_SERVER_VERSION env var,
+  // the `scrcpy --version` binary, or the built-in default constant.
+  source: "env" | "binary" | "default"
+}
+
 /**
- * Detect the installed scrcpy version by running `scrcpy --version`.
- * Falls back to the SCRCPY_SERVER_VERSION constant if detection fails.
+ * Resolve the scrcpy version and where it came from, without memoization.
+ * Prefer detectScrcpyVersionInfo() at call sites; this uncached form exists
+ * so the resolution ladder can be unit-tested independently of the cache.
  */
-export function detectScrcpyVersion(): string {
+export function computeScrcpyVersionInfo(): DetectedVersion {
   const envVersion = process.env.SCRCPY_SERVER_VERSION
   if (envVersion) {
-    return envVersion
+    return { version: envVersion, source: "env" }
   }
 
   try {
@@ -536,13 +560,60 @@ export function detectScrcpyVersion(): string {
     // or: "scrcpy 1.25 <https://github.com/Genymobile/scrcpy>"
     const match = output.match(/scrcpy\s+(\d+\.\d+(?:\.\d+)?)/)
     if (match) {
-      return match[1]
+      return { version: match[1], source: "binary" }
     }
   } catch {
     // scrcpy CLI not available, fall through
   }
 
-  return SCRCPY_SERVER_VERSION
+  return { version: SCRCPY_SERVER_VERSION, source: "default" }
+}
+
+/**
+ * Detect the installed scrcpy version and its source. Memoized: the version
+ * cannot change mid-process, so every caller sees a single consistent result
+ * and the `source` can never disagree with the `version` it accompanies.
+ */
+export function detectScrcpyVersionInfo(): DetectedVersion {
+  if (!cachedScrcpyVersion) {
+    cachedScrcpyVersion = computeScrcpyVersionInfo()
+  }
+  return cachedScrcpyVersion
+}
+
+/**
+ * Detect the installed scrcpy version string. Falls back to the
+ * SCRCPY_SERVER_VERSION constant if detection fails.
+ */
+export function detectScrcpyVersion(): string {
+  return detectScrcpyVersionInfo().version
+}
+
+interface ParsedVersion {
+  major: number
+  minor: number
+  patch: number
+}
+
+function parseVersion(version: string): ParsedVersion {
+  const parts = version.split(".").map(Number)
+  return {
+    major: parts[0] || 0,
+    minor: parts[1] || 0,
+    patch: parts[2] || 0,
+  }
+}
+
+function isVersionAtLeast(
+  version: string,
+  minMajor: number,
+  minMinor: number,
+  minPatch: number
+): boolean {
+  const v = parseVersion(version)
+  if (v.major !== minMajor) return v.major > minMajor
+  if (v.minor !== minMinor) return v.minor > minMinor
+  return v.patch >= minPatch
 }
 
 function generateScid(): number {
@@ -580,21 +651,27 @@ export async function removePortForwarding(serial: string, port: number): Promis
   }
 }
 
-export async function startScrcpyServer(
+// scrcpy 4.0 renamed send_codec_meta to send_stream_meta (whose header gains a
+// 4-byte flags field, see V4_DEVICE_META_SIZE). All other send_* options kept
+// their names and defaults, and the server ignores unknown options with a
+// warning, so the arg lists differ only in that one flag. Exported for tests.
+export function buildServerArgs(
   serial: string,
   scid: number,
+  version: string,
   options: ScrcpySessionOptions = {}
-): Promise<void> {
+): string[] {
   const {
     maxSize = 1024,
     maxFps = 30,
     videoBitRate = 8000000,
   } = options
 
-  const version = detectScrcpyVersion()
-  console.error(`[scrcpy] Using scrcpy server version: ${version}`)
+  const streamMetaArg = isVersionAtLeast(version, 4, 0, 0)
+    ? "send_stream_meta=true"
+    : "send_codec_meta=true"
 
-  const serverArgs = [
+  return [
     "-s", serial, "shell",
     `CLASSPATH=${SCRCPY_SERVER_PATH_LOCAL}`,
     "app_process",
@@ -617,9 +694,19 @@ export async function startScrcpyServer(
     "send_device_meta=true",
     "send_frame_meta=false",
     "send_dummy_byte=true",
-    "send_codec_meta=true",
+    streamMetaArg,
     "video_codec=h264",
   ]
+}
+
+export async function startScrcpyServer(
+  serial: string,
+  scid: number,
+  options: ScrcpySessionOptions = {}
+): Promise<void> {
+  const version = detectScrcpyVersion()
+  console.error(`[scrcpy] Using scrcpy server version: ${version}`)
+  const serverArgs = buildServerArgs(serial, scid, version, options)
 
   return new Promise((resolve, reject) => {
     const child = spawn(ADB_PATH, serverArgs, {
@@ -725,9 +812,33 @@ interface DeviceMetaResult {
   overflow: Buffer
 }
 
+export interface VideoMetaLayout {
+  metaSize: number
+  widthOffset: number
+  heightOffset: number
+}
+
+// Byte layout of the video-socket metadata header for a given server version.
+// Exported for tests.
+export function videoMetaLayout(version: string): VideoMetaLayout {
+  if (isVersionAtLeast(version, 4, 0, 0)) {
+    return {
+      metaSize: V4_DEVICE_META_SIZE,
+      widthOffset: V4_VIDEO_WIDTH_OFFSET,
+      heightOffset: V4_VIDEO_HEIGHT_OFFSET,
+    }
+  }
+  return {
+    metaSize: DEVICE_META_SIZE,
+    widthOffset: VIDEO_WIDTH_OFFSET,
+    heightOffset: VIDEO_HEIGHT_OFFSET,
+  }
+}
+
 const receiveDeviceMeta = async (
   socket: net.Socket,
-  port: number
+  port: number,
+  layout: VideoMetaLayout
 ): Promise<DeviceMetaResult> =>
   new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -741,7 +852,7 @@ const receiveDeviceMeta = async (
     const onData = (chunk: Buffer) => {
       buffer = Buffer.concat([buffer, chunk])
 
-      if (buffer.length >= DEVICE_META_SIZE) {
+      if (buffer.length >= layout.metaSize) {
         clearTimeout(timer)
         socket.off("data", onData)
         socket.off("error", onError)
@@ -752,13 +863,13 @@ const receiveDeviceMeta = async (
           .replace(/\0+$/, "")
         console.error(`[scrcpy] Device name: ${deviceName}`)
 
-        const width = buffer.readUInt32BE(VIDEO_WIDTH_OFFSET)
-        const height = buffer.readUInt32BE(VIDEO_HEIGHT_OFFSET)
+        const width = buffer.readUInt32BE(layout.widthOffset)
+        const height = buffer.readUInt32BE(layout.heightOffset)
         console.error(`[scrcpy] Screen size: ${width}x${height}`)
 
         // Any bytes beyond the metadata are the start of the h264 stream
-        const overflow = buffer.length > DEVICE_META_SIZE
-          ? Buffer.from(buffer.subarray(DEVICE_META_SIZE))
+        const overflow = buffer.length > layout.metaSize
+          ? Buffer.from(buffer.subarray(layout.metaSize))
           : Buffer.alloc(0)
 
         resolve({ width, height, overflow })
@@ -850,6 +961,8 @@ export async function startSession(
     throw err
   }
 
+  const version = detectScrcpyVersion()
+
   const connectTimeout = 10000
   const retryInterval = 100
   const deadline = Date.now() + connectTimeout
@@ -859,6 +972,8 @@ export async function startSession(
   // In forward tunnel mode, adb forward accepts TCP connections even when
   // the server hasn't created its LocalServerSocket yet. connectAndVerify
   // reads the dummy byte after TCP connect to confirm the server is live.
+  // (scrcpy 4.x still sends the dummy byte; only the codec-meta header
+  // layout differs, handled below via videoMetaLayout.)
   while (Date.now() < deadline) {
     try {
       socket = await connectAndVerify(port, 2000)
@@ -934,6 +1049,7 @@ export async function startSession(
     // bytes off the socket regardless so the h264 stream isn't corrupted,
     // but the width/height here are the *downscaled encoder frame* size
     // (e.g. 576x1024 at max_size=1024), NOT the device's native resolution.
+    // The header layout depends on the server version (see videoMetaLayout).
     //
     // If metadata never arrives (e.g. the device/emulator has no usable h264
     // encoder, as on CI's swiftshader emulator) we don't hard-fail the whole
@@ -941,9 +1057,9 @@ export async function startSession(
     // fall back to `adb screencap`. We degrade to a video-less session instead.
     let videoAvailable = true
     let frameSize: { width: number; height: number }
-    let overflow = Buffer.alloc(0)
+    let overflow: Buffer = Buffer.alloc(0)
     try {
-      const meta = await receiveDeviceMeta(socket, port)
+      const meta = await receiveDeviceMeta(socket, port, videoMetaLayout(version))
       frameSize = { width: meta.width, height: meta.height }
       overflow = meta.overflow
     } catch (err) {

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -589,6 +589,14 @@ export function detectScrcpyVersion(): string {
   return detectScrcpyVersionInfo().version
 }
 
+/**
+ * Test-only: clear the memoized version so detectScrcpyVersionInfo() can be
+ * exercised fresh without depending on call order across test files.
+ */
+export function __resetScrcpyVersionCacheForTests(): void {
+  cachedScrcpyVersion = null
+}
+
 interface ParsedVersion {
   major: number
   minor: number

--- a/tests/scrcpy-version.test.ts
+++ b/tests/scrcpy-version.test.ts
@@ -6,6 +6,7 @@ import {
   computeScrcpyVersionInfo,
   detectScrcpyVersionInfo,
   detectScrcpyVersion,
+  __resetScrcpyVersionCacheForTests,
 } from "../src/utils/scrcpy.js"
 import {
   DEVICE_META_SIZE,
@@ -155,9 +156,8 @@ describe("computeScrcpyVersionInfo", () => {
 })
 
 describe("detectScrcpyVersionInfo", () => {
-  // This is the only test in the file that populates the module-level cache,
-  // so it owns the first call and can assert memoization end to end.
   it("memoizes the first resolution and keeps version/source consistent", () => {
+    __resetScrcpyVersionCacheForTests()
     const originalEnv = process.env.SCRCPY_SERVER_VERSION
     delete process.env.SCRCPY_SERVER_VERSION
     execSyncMock.mockReset()
@@ -180,6 +180,7 @@ describe("detectScrcpyVersionInfo", () => {
       } else {
         process.env.SCRCPY_SERVER_VERSION = originalEnv
       }
+      __resetScrcpyVersionCacheForTests()
     }
   })
 })

--- a/tests/scrcpy-version.test.ts
+++ b/tests/scrcpy-version.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { execSync } from "child_process"
+import {
+  buildServerArgs,
+  videoMetaLayout,
+  computeScrcpyVersionInfo,
+  detectScrcpyVersionInfo,
+  detectScrcpyVersion,
+} from "../src/utils/scrcpy.js"
+import {
+  DEVICE_META_SIZE,
+  VIDEO_WIDTH_OFFSET,
+  VIDEO_HEIGHT_OFFSET,
+  V4_DEVICE_META_SIZE,
+  V4_VIDEO_WIDTH_OFFSET,
+  V4_VIDEO_HEIGHT_OFFSET,
+  SCRCPY_SERVER_VERSION,
+} from "../src/utils/constants.js"
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>()
+  return { ...actual, execSync: vi.fn() }
+})
+
+const execSyncMock = vi.mocked(execSync)
+
+describe("buildServerArgs", () => {
+  const commonWireFormatArgs = [
+    "control=true",
+    "cleanup=true",
+    "send_device_meta=true",
+    "send_frame_meta=false",
+    "send_dummy_byte=true",
+    "video_codec=h264",
+  ]
+
+  it("requests codec meta on scrcpy 3.x", () => {
+    const args = buildServerArgs("SERIAL", 0x1234, "3.3.4")
+    expect(args).toContain("send_codec_meta=true")
+    expect(args).not.toContain("send_stream_meta=true")
+  })
+
+  it("requests stream meta on scrcpy 4.x (send_codec_meta was renamed)", () => {
+    const args = buildServerArgs("SERIAL", 0x1234, "4.0")
+    expect(args).toContain("send_stream_meta=true")
+    expect(args).not.toContain("send_codec_meta=true")
+  })
+
+  it.each(["3.3.4", "4.0", "4.1.2"])(
+    "pins the shared wire-format options explicitly for version %s",
+    (version) => {
+      const args = buildServerArgs("SERIAL", 0x1234, version)
+      for (const arg of commonWireFormatArgs) {
+        expect(args).toContain(arg)
+      }
+    }
+  )
+
+  it("applies session options for all versions", () => {
+    for (const version of ["3.3.4", "4.0"]) {
+      const args = buildServerArgs("SERIAL", 0x1234, version, {
+        maxSize: 800,
+        maxFps: 15,
+        videoBitRate: 4000000,
+      })
+      expect(args).toContain("max_size=800")
+      expect(args).toContain("max_fps=15")
+      expect(args).toContain("video_bit_rate=4000000")
+    }
+  })
+})
+
+describe("videoMetaLayout", () => {
+  it("uses the 76-byte header for scrcpy 3.x", () => {
+    expect(videoMetaLayout("3.3.4")).toEqual({
+      metaSize: DEVICE_META_SIZE,
+      widthOffset: VIDEO_WIDTH_OFFSET,
+      heightOffset: VIDEO_HEIGHT_OFFSET,
+    })
+  })
+
+  it.each(["4.0", "4.0.1", "4.1", "5.0"])(
+    "uses the 80-byte stream-meta header for version %s",
+    (version) => {
+      expect(videoMetaLayout(version)).toEqual({
+        metaSize: V4_DEVICE_META_SIZE,
+        widthOffset: V4_VIDEO_WIDTH_OFFSET,
+        heightOffset: V4_VIDEO_HEIGHT_OFFSET,
+      })
+    }
+  )
+
+  it("treats pre-4.0 versions as legacy", () => {
+    for (const version of ["1.25", "2.7", "3.9.9"]) {
+      expect(videoMetaLayout(version).metaSize).toBe(DEVICE_META_SIZE)
+    }
+  })
+})
+
+describe("computeScrcpyVersionInfo", () => {
+  const originalEnv = process.env.SCRCPY_SERVER_VERSION
+
+  beforeEach(() => {
+    execSyncMock.mockReset()
+    delete process.env.SCRCPY_SERVER_VERSION
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SCRCPY_SERVER_VERSION
+    } else {
+      process.env.SCRCPY_SERVER_VERSION = originalEnv
+    }
+  })
+
+  it("resolves from the SCRCPY_SERVER_VERSION env var without spawning the binary", () => {
+    process.env.SCRCPY_SERVER_VERSION = "4.2"
+    expect(computeScrcpyVersionInfo()).toEqual({ version: "4.2", source: "env" })
+    expect(execSyncMock).not.toHaveBeenCalled()
+  })
+
+  it("resolves from the scrcpy binary when the env var is unset", () => {
+    execSyncMock.mockReturnValue(
+      "scrcpy 4.0 <https://github.com/Genymobile/scrcpy>\n"
+    )
+    expect(computeScrcpyVersionInfo()).toEqual({ version: "4.0", source: "binary" })
+  })
+
+  it("falls back to the default when the binary output does not match", () => {
+    execSyncMock.mockReturnValue("not a scrcpy version line")
+    expect(computeScrcpyVersionInfo()).toEqual({
+      version: SCRCPY_SERVER_VERSION,
+      source: "default",
+    })
+  })
+
+  it("falls back to the default when the binary is unavailable", () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("command not found: scrcpy")
+    })
+    expect(computeScrcpyVersionInfo()).toEqual({
+      version: SCRCPY_SERVER_VERSION,
+      source: "default",
+    })
+  })
+
+  it("never reports a source that disagrees with its version", () => {
+    // Regression guard: version and source must come from one resolution, so
+    // a binary-derived version can never be labelled 'default' and vice versa.
+    execSyncMock.mockReturnValue("scrcpy 3.3.4 <url>\n")
+    const info = computeScrcpyVersionInfo()
+    expect(info.source).toBe("binary")
+    expect(info.version).toBe("3.3.4")
+  })
+})
+
+describe("detectScrcpyVersionInfo", () => {
+  // This is the only test in the file that populates the module-level cache,
+  // so it owns the first call and can assert memoization end to end.
+  it("memoizes the first resolution and keeps version/source consistent", () => {
+    const originalEnv = process.env.SCRCPY_SERVER_VERSION
+    delete process.env.SCRCPY_SERVER_VERSION
+    execSyncMock.mockReset()
+    execSyncMock.mockReturnValue("scrcpy 4.0 <https://github.com/Genymobile/scrcpy>\n")
+
+    try {
+      const first = detectScrcpyVersionInfo()
+      expect(first).toEqual({ version: "4.0", source: "binary" })
+      expect(detectScrcpyVersion()).toBe(first.version)
+
+      // Cache is now populated; a later resolution failure must not change it.
+      execSyncMock.mockImplementation(() => {
+        throw new Error("binary vanished")
+      })
+      expect(detectScrcpyVersionInfo()).toEqual(first)
+      expect(detectScrcpyVersion()).toBe("4.0")
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.SCRCPY_SERVER_VERSION
+      } else {
+        process.env.SCRCPY_SERVER_VERSION = originalEnv
+      }
+    }
+  })
+})


### PR DESCRIPTION
Add support for scrcpy 4.x which renamed send_codec_meta to send_stream_meta and extended the video metadata header from 76 to 80 bytes (new 4-byte session-meta flags field). Introduce version-aware server arg construction (buildServerArgs) and byte offset resolution (videoMetaLayout) based on the detected server version.

Refactor version detection to return both the version string and its resolution source (env/binary/default), with process-level memoization so every caller sees a consistent result. Expose this via a new "version" MCP tool that reports the active scrcpy version and its source.

Also fix findFfmpeg to check the execute permission bit before using a static ffmpeg binary, and add a README note for OpenCode users about using "environment" instead of "env" in MCP server configuration.