### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "scrcpy-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "homepage": "https://github.com/JuanCF/scrcpy-mcp",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/JuanCF/scrcpy-mcp",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "scrcpy-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: scrcpy-mcp
-version: 0.3.0
+version: 0.4.0
 description: MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices
 startCommand:
   type: stdio


### PR DESCRIPTION
Bump version from 0.3.0 to 0.4.0 in package.json and package-lock.json. This minor version increments for the scrcpy 4.x compatibility feature and version detection tool added since v0.3.0.