### PR TITLE
fix: parse "no permissions" as full device state

### DIFF
--- a/src/utils/adb.ts
+++ b/src/utils/adb.ts
@@ -97,7 +97,7 @@ export function parseDeviceList(stdout: string): DeviceInfo[] {
     if (!line.trim()) continue;
 
     const match = line.match(
-      /^(\S+)\s+(\S+)(?:\s+(.*))?$/
+      /^(\S+)\s+(no permissions|\S+)(?:\s+(.*))?$/
     );
 
     if (match) {

--- a/tests/adb.test.ts
+++ b/tests/adb.test.ts
@@ -61,6 +61,27 @@ describe("parseDeviceList", () => {
     ])
   })
 
+  // Regression: "no permissions" is a multi-word adb device state.  The old
+  // regex captured only "no" as the state and left "permissions ..." in the
+  // info blob, so callers saw state "no" instead of "no permissions".
+  it("preserves the multi-word 'no permissions' state", () => {
+    const stdout =
+      "List of devices attached\r\n" +
+      "1234567890abcdef       no permissions usb:1 " +
+      "product:sample_product model:sample_model device:sample " +
+      "transport_id:1\r\n"
+
+    expect(parseDeviceList(stdout)).toEqual([
+      {
+        serial: "1234567890abcdef",
+        state: "no permissions",
+        model: "sample_model",
+        product: "sample_product",
+        transportId: "1",
+      },
+    ])
+  })
+
   it("parses multiple attached devices", () => {
     const stdout =
       "List of devices attached\r\n" +


### PR DESCRIPTION
Update the device-line regex in parseDeviceList to recognize "no permissions" as the complete state before falling back to the generic single-token state.

ADB can emit a device line like:
  1234567890abcdef  no permissions usb:1 product:...

The previous regex used \S+ for the state, which captured only "no" and left "permissions ..." in the trailing info blob. Callers saw state "no" instead of "no permissions", so the multi-word state was silently corrupted.

Keep existing state and info parsing intact by using the alternation "no permissions|\S+" — ordered so the literal is tried first.

Add a regression fixture covering an adb devices -l line with the "no permissions" state and verify the parsed device preserves the state and does not move "permissions" into the info fields.