### PR TITLE
test: add integration suite and fix two tools it depends on

### DIFF
--- a/src/tools/apps.ts
+++ b/src/tools/apps.ts
@@ -310,7 +310,7 @@ export function registerAppTools(server: McpServer): void {
         const output = await execAdbShell(s, "dumpsys activity activities")
         // Format: mResumedActivity: ActivityRecord{xxxx u0 com.pkg/.Activity t1}
         const match = output.match(
-          /mResumedActivity[=: ]+ActivityRecord\{[^}]+\s+([^\s/}]+)(\/[^\s}]+)?/
+          /m?ResumedActivity\s*[:=]\s*ActivityRecord\{[^}]+\s+u\d+\s+([^\s/}]+)(\/[^\s}]+)?/i
         )
         if (!match) {
           return toolError("Could not determine current activity")

--- a/src/tools/files.ts
+++ b/src/tools/files.ts
@@ -193,7 +193,12 @@ export function registerFileTools(server: McpServer): void {
       try {
         const s = await resolveSerial(serial)
         const safePath = devicePath.replace(/'/g, "'\\''")
-        const output = await execAdbShell(s, `ls -la '${safePath}'`)
+        // -H dereferences only the operand, so a symlinked directory such as
+        // /sdcard (-> /storage/self/primary) lists its target's contents rather
+        // than the link itself. Do NOT use -L: it dereferences every entry too,
+        // and a single dangling symlink makes ls print an error and exit 1,
+        // which execAdb turns into a rejection for the whole directory.
+        const output = await execAdbShell(s, `ls -laH '${safePath}'`)
         const entries = parseLsOutput(output)
         const structured = { path: devicePath, count: entries.length, entries }
         return {

--- a/tests/integration/apps.test.ts
+++ b/tests/integration/apps.test.ts
@@ -36,8 +36,15 @@ describe("App Tools Integration", () => {
   }, 30000)
 
   afterAll(async () => {
+    // Insurance for the app_start fast-path session: if its own afterAll threw,
+    // the device would stay busy and every later file's start_session would fail.
+    try {
+      await callTool("stop_session")
+    } catch {
+      // Ignore if no session
+    }
     await disconnectClient()
-  })
+  }, 30000)
 
   describe("app_list", () => {
     it("should list installed packages", async () => {
@@ -74,17 +81,63 @@ describe("App Tools Integration", () => {
     })
   })
 
+  // app_start has two execution paths: the scrcpy control-socket fast path when a
+  // session is live, and the ADB `monkey` fallback otherwise. Both report the same
+  // success message, so `source` is the only thing that tells them apart — hence a
+  // case per path, each asserting it.
   describe("app_start", () => {
-    it("should launch the Settings app", async () => {
+    it("should launch the Settings app via ADB when no session is active", async () => {
+      // This file's server process starts out sessionless, but say so explicitly:
+      // a leftover session would route this through the fast path instead and the
+      // fallback would go untested without the assertion below ever failing.
+      await callTool("stop_session").catch(() => {})
+
       const result = await callTool("app_start", { packageName: SETTINGS_PACKAGE })
       const parsed = parseResult(result) as {
         success: boolean
         message: string
+        source?: string
       }
 
       expect(parsed.success).toBe(true)
       expect(parsed.message).toContain(SETTINGS_PACKAGE)
+      expect(parsed.source).toBe("adb")
     }, 30000)
+
+    describe("with an active scrcpy session", () => {
+      let sessionStarted = false
+
+      beforeAll(async () => {
+        const result = await callTool("start_session", { maxSize: 800, maxFps: 15 })
+        const data = parseResult(result) as { status: string; message?: string }
+        // Surface the server-side message: without a connected session this
+        // describe would be testing the fallback path a second time.
+        expect(data.status, `start_session failed: ${data.message}`).toBe("connected")
+        sessionStarted = true
+      }, 30000)
+
+      afterAll(async () => {
+        // The device allows only one encoder session, so hand it back before the
+        // remaining files (session.test.ts included) try to open their own.
+        if (sessionStarted) await callTool("stop_session").catch(() => {})
+      }, 30000)
+
+      it("should launch the Settings app via scrcpy", async () => {
+        const result = await callTool("app_start", { packageName: SETTINGS_PACKAGE })
+        const parsed = parseResult(result) as {
+          success: boolean
+          message: string
+          source?: string
+        }
+
+        expect(parsed.success).toBe(true)
+        expect(parsed.message).toContain(SETTINGS_PACKAGE)
+        // "adb" here would mean startAppViaScrcpy threw and the handler quietly
+        // fell back: the launch still succeeds, so only `source` exposes that the
+        // fast path is broken.
+        expect(parsed.source).toBe("scrcpy")
+      }, 30000)
+    })
   })
 
   describe("app_current", () => {

--- a/tests/integration/apps.test.ts
+++ b/tests/integration/apps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
-import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+import { connectClient, disconnectClient, callTool, parseResult, stopSessionOrFail } from "./mcp-client.js"
 
 const SETTINGS_PACKAGE = "com.android.settings"
 
@@ -38,12 +38,13 @@ describe("App Tools Integration", () => {
   afterAll(async () => {
     // Insurance for the app_start fast-path session: if its own afterAll threw,
     // the device would stay busy and every later file's start_session would fail.
+    // Disconnect in a finally so a failed stop still tears the server down —
+    // otherwise the stdio child outlives the run and vitest hangs on it.
     try {
-      await callTool("stop_session")
-    } catch {
-      // Ignore if no session
+      await stopSessionOrFail()
+    } finally {
+      await disconnectClient()
     }
-    await disconnectClient()
   }, 30000)
 
   describe("app_list", () => {
@@ -90,7 +91,7 @@ describe("App Tools Integration", () => {
       // This file's server process starts out sessionless, but say so explicitly:
       // a leftover session would route this through the fast path instead and the
       // fallback would go untested without the assertion below ever failing.
-      await callTool("stop_session").catch(() => {})
+      await stopSessionOrFail()
 
       const result = await callTool("app_start", { packageName: SETTINGS_PACKAGE })
       const parsed = parseResult(result) as {
@@ -119,7 +120,7 @@ describe("App Tools Integration", () => {
       afterAll(async () => {
         // The device allows only one encoder session, so hand it back before the
         // remaining files (session.test.ts included) try to open their own.
-        if (sessionStarted) await callTool("stop_session").catch(() => {})
+        if (sessionStarted) await stopSessionOrFail()
       }, 30000)
 
       it("should launch the Settings app via scrcpy", async () => {

--- a/tests/integration/apps.test.ts
+++ b/tests/integration/apps.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+const SETTINGS_PACKAGE = "com.android.settings"
+
+interface CurrentApp {
+  packageName: string
+  activity: string | null
+}
+
+/**
+ * Poll app_current until it reports `expected`, or the timeout elapses.
+ *
+ * Always resolves with the last reading so the caller's assertion reports the
+ * package that was actually in the foreground, rather than a bare timeout.
+ */
+async function waitForForegroundApp(
+  expected: string,
+  timeoutMs = 10000,
+  intervalMs = 500
+): Promise<CurrentApp> {
+  const deadline = Date.now() + timeoutMs
+  let last: CurrentApp = { packageName: "", activity: null }
+
+  for (;;) {
+    last = parseResult(await callTool("app_current")) as CurrentApp
+    if (last.packageName === expected || Date.now() >= deadline) return last
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+}
+
+describe("App Tools Integration", () => {
+  beforeAll(async () => {
+    await connectClient()
+    await callTool("screen_on")
+  }, 30000)
+
+  afterAll(async () => {
+    await disconnectClient()
+  })
+
+  describe("app_list", () => {
+    it("should list installed packages", async () => {
+      const result = await callTool("app_list")
+      const parsed = parseResult(result) as {
+        count: number
+        packages: string[]
+      }
+
+      expect(parsed.count).toBeGreaterThan(0)
+      expect(parsed.packages.length).toBe(parsed.count)
+      expect(parsed.packages.length).toBeGreaterThan(0)
+    })
+
+    it("should filter installed packages", async () => {
+      const result = await callTool("app_list", { filter: "android" })
+      const parsed = parseResult(result) as {
+        count: number
+        packages: string[]
+      }
+
+      expect(parsed.packages.length).toBeGreaterThan(0)
+      expect(parsed.packages.every((p) => p.toLowerCase().includes("android"))).toBe(true)
+    })
+
+    it("should list system packages only", async () => {
+      const result = await callTool("app_list", { system: true })
+      const parsed = parseResult(result) as {
+        count: number
+        packages: string[]
+      }
+
+      expect(parsed.count).toBeGreaterThan(0)
+    })
+  })
+
+  describe("app_start", () => {
+    it("should launch the Settings app", async () => {
+      const result = await callTool("app_start", { packageName: SETTINGS_PACKAGE })
+      const parsed = parseResult(result) as {
+        success: boolean
+        message: string
+      }
+
+      expect(parsed.success).toBe(true)
+      expect(parsed.message).toContain(SETTINGS_PACKAGE)
+    }, 30000)
+  })
+
+  describe("app_current", () => {
+    it("should return the foreground app", async () => {
+      await callTool("app_start", { packageName: SETTINGS_PACKAGE })
+
+      // app_start fires `monkey -p ...` and returns without waiting for the
+      // activity to resume, so poll instead of reading app_current once — the
+      // launcher can still be the resumed activity for a moment after.
+      const parsed = await waitForForegroundApp(SETTINGS_PACKAGE)
+
+      expect(parsed.packageName).toBe(SETTINGS_PACKAGE)
+      expect(typeof parsed.activity === "string" || parsed.activity === null).toBe(true)
+    }, 30000)
+  })
+
+  describe("app_stop", () => {
+    it("should force-stop the Settings app", async () => {
+      const result = await callTool("app_stop", { packageName: SETTINGS_PACKAGE })
+      const parsed = parseResult(result) as {
+        success: boolean
+        message: string
+      }
+
+      expect(parsed.success).toBe(true)
+      expect(parsed.message.toLowerCase()).toContain("stopped")
+    })
+  })
+
+  describe("app_install validation", () => {
+    it("should reject a missing APK file", async () => {
+      const result = await callTool("app_install", {
+        apkPath: "/nonexistent/scrcpy-mcp-test.apk",
+      })
+      const parsed = parseResult(result) as {
+        error?: boolean
+        message: string
+      }
+
+      expect(result.isError || parsed.error).toBe(true)
+      expect(parsed.message).toContain("does not exist")
+    })
+  })
+
+  describe("app_uninstall validation", () => {
+    it("should reject an invalid package name", async () => {
+      const result = await callTool("app_uninstall", {
+        packageName: "not a valid package",
+      })
+      const parsed = parseResult(result) as {
+        error?: boolean
+        message: string
+      }
+
+      expect(result.isError || parsed.error).toBe(true)
+    })
+  })
+
+  const testApkPath = process.env.TEST_APK_PATH
+  const testApkPackage = process.env.TEST_APK_PACKAGE
+  const canRunInstallRoundTrip = Boolean(testApkPath && testApkPackage)
+
+  describe.skipIf(!canRunInstallRoundTrip)("app_install / app_uninstall round-trip", () => {
+    it("should install and uninstall the test APK", async () => {
+      const installResult = await callTool("app_install", { apkPath: testApkPath })
+      const installParsed = parseResult(installResult) as {
+        success: boolean
+        message: string
+      }
+      expect(installParsed.success).toBe(true)
+
+      const uninstallResult = await callTool("app_uninstall", { packageName: testApkPackage })
+      const uninstallParsed = parseResult(uninstallResult) as {
+        success: boolean
+        message: string
+      }
+      expect(uninstallParsed.success).toBe(true)
+    }, 60000)
+  })
+})

--- a/tests/integration/apps.test.ts
+++ b/tests/integration/apps.test.ts
@@ -20,7 +20,7 @@ async function waitForForegroundApp(
   intervalMs = 500
 ): Promise<CurrentApp> {
   const deadline = Date.now() + timeoutMs
-  let last: CurrentApp = { packageName: "", activity: null }
+  let last: CurrentApp
 
   for (;;) {
     last = parseResult(await callTool("app_current")) as CurrentApp
@@ -156,12 +156,20 @@ describe("App Tools Integration", () => {
       }
       expect(installParsed.success).toBe(true)
 
-      const uninstallResult = await callTool("app_uninstall", { packageName: testApkPackage })
-      const uninstallParsed = parseResult(uninstallResult) as {
-        success: boolean
-        message: string
+      // Past this point the APK is on the device, so the uninstall has to happen
+      // even if the assertion below fails — otherwise a red run leaves the test
+      // app installed and the next run's install is no longer a clean one.
+      try {
+        const uninstallResult = await callTool("app_uninstall", { packageName: testApkPackage })
+        const uninstallParsed = parseResult(uninstallResult) as {
+          success: boolean
+          message: string
+        }
+        expect(uninstallParsed.success).toBe(true)
+      } finally {
+        // No-op when the uninstall above succeeded; the package is already gone.
+        await callTool("app_uninstall", { packageName: testApkPackage }).catch(() => {})
       }
-      expect(uninstallParsed.success).toBe(true)
     }, 60000)
   })
 })

--- a/tests/integration/clipboard.test.ts
+++ b/tests/integration/clipboard.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+// Reading the clipboard requires the scrcpy control path available on API 31+.
+// Probe through the MCP client rather than a bare `adb` from PATH, so the same
+// device (and the same ADB_PATH) is used as by every other call in the suite.
+// A failed probe must fail the run, not silently skip the read tests green.
+let sdkLevel = 0
+
+describe("Clipboard Tools Integration", () => {
+  beforeAll(async () => {
+    await connectClient()
+
+    const sdkResult = await callTool("shell_exec", {
+      command: "getprop ro.build.version.sdk",
+    })
+    sdkLevel = parseInt(String(parseResult(sdkResult)).trim(), 10)
+    expect(
+      Number.isInteger(sdkLevel) && sdkLevel > 0,
+      `could not read ro.build.version.sdk: ${String(parseResult(sdkResult))}`
+    ).toBe(true)
+
+    await callTool("start_session")
+  }, 30000)
+
+  afterAll(async () => {
+    try {
+      await callTool("stop_session")
+    } catch {
+      // ignore
+    }
+    await disconnectClient()
+  }, 30000)
+
+  const text = `scrcpy-mcp-clipboard-${Date.now()}`
+
+  describe("clipboard_set", () => {
+    it("should set the device clipboard", async () => {
+      const result = await callTool("clipboard_set", { text })
+      const parsed = parseResult(result) as {
+        success: boolean
+        message: string
+        source: string
+      }
+
+      expect(parsed.success).toBe(true)
+      expect(parsed.message).toContain(text)
+      expect(["scrcpy", "adb"]).toContain(parsed.source)
+    })
+  })
+
+  describe("clipboard_get", () => {
+    // Skipped at runtime, not collection time: sdkLevel is only known after
+    // beforeAll has run, so describe.skipIf would always see the initial 0.
+    it("should read the device clipboard", async (ctx) => {
+      if (sdkLevel < 31) {
+        ctx.skip(`clipboard_get requires API 31+, device is API ${sdkLevel}`)
+        return
+      }
+
+      await callTool("clipboard_set", { text })
+      const result = await callTool("clipboard_get")
+      const parsed = parseResult(result) as {
+        content: string
+        source: string
+      }
+
+      expect(parsed.content).toBe(text)
+      expect(["scrcpy", "adb"]).toContain(parsed.source)
+    })
+  })
+})

--- a/tests/integration/files.test.ts
+++ b/tests/integration/files.test.ts
@@ -1,0 +1,100 @@
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+describe("File Tools Integration", () => {
+  const timestamp = Date.now()
+  const testFileName = `scrcpy-mcp-file-test-${timestamp}.txt`
+  const localSource = path.join(os.tmpdir(), testFileName)
+  const localDownload = path.join(os.tmpdir(), `downloaded-${testFileName}`)
+  const remotePath = `/sdcard/${testFileName}`
+  const testContent = "Hello from scrcpy-mcp integration tests!"
+
+  beforeAll(async () => {
+    await connectClient()
+    fs.writeFileSync(localSource, testContent, "utf8")
+  }, 30000)
+
+  afterAll(async () => {
+    try {
+      fs.unlinkSync(localSource)
+    } catch {
+      // ignore
+    }
+    try {
+      fs.unlinkSync(localDownload)
+    } catch {
+      // ignore
+    }
+    try {
+      await callTool("shell_exec", { command: `rm -f ${remotePath}` })
+    } catch {
+      // ignore
+    }
+    await disconnectClient()
+  })
+
+  describe("file_push", () => {
+    it("should push a file to the device", async () => {
+      const result = await callTool("file_push", {
+        localPath: localSource,
+        remotePath,
+      })
+      const parsed = parseResult(result) as {
+        success: boolean
+        message: string
+      }
+
+      expect(parsed.success).toBe(true)
+      expect(parsed.message.toLowerCase()).toContain("push")
+    })
+  })
+
+  describe("file_list", () => {
+    it("should list the sdcard directory", async () => {
+      const result = await callTool("file_list", { path: "/sdcard" })
+      const parsed = parseResult(result) as {
+        path: string
+        count: number
+        entries: Array<{
+          name: string
+          permissions: string
+          isDirectory: boolean
+        }>
+      }
+
+      expect(parsed.path).toBe("/sdcard")
+      expect(parsed.count).toBeGreaterThan(0)
+      expect(parsed.entries.length).toBe(parsed.count)
+    })
+
+    it("should include the pushed file", async () => {
+      const result = await callTool("file_list", { path: "/sdcard" })
+      const parsed = parseResult(result) as {
+        count: number
+        entries: Array<{ name: string }>
+      }
+
+      expect(parsed.entries.some((e) => e.name === testFileName)).toBe(true)
+    })
+  })
+
+  describe("file_pull", () => {
+    it("should pull the file back to the host", async () => {
+      const result = await callTool("file_pull", {
+        remotePath,
+        localPath: localDownload,
+      })
+      const parsed = parseResult(result) as {
+        success: boolean
+        message: string
+      }
+
+      expect(parsed.success).toBe(true)
+      expect(fs.existsSync(localDownload)).toBe(true)
+      expect(fs.readFileSync(localDownload, "utf8")).toBe(testContent)
+    })
+  })
+})

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -1,0 +1,54 @@
+import { execAdbShell, resolveSerial } from "../../src/utils/adb.js"
+
+// The integration suite drives a real phone, so it must hand the device back in
+// the state it found it. Anything that outlives a single test file is captured
+// here rather than in per-file hooks: a file that crashes mid-run skips its own
+// afterAll, but globalSetup's teardown still runs.
+
+const SUITE_SCREEN_OFF_TIMEOUT = "600000"
+
+let serial: string | null = null
+let previousScreenOffTimeout: string | null = null
+
+/** Run an adb shell command, swallowing failures so one broken step can't mask the rest. */
+async function tryShell(command: string): Promise<void> {
+  if (!serial) return
+  try {
+    await execAdbShell(serial, command)
+  } catch {
+    // best effort — teardown must keep going
+  }
+}
+
+export async function setup(): Promise<void> {
+  serial = await resolveSerial()
+
+  // Keep the screen alive for the whole run; restored in teardown.
+  const current = await execAdbShell(serial, "settings get system screen_off_timeout")
+  const trimmed = current.trim()
+  // `settings get` prints "null" for an unset key — nothing to restore in that case.
+  previousScreenOffTimeout = trimmed && trimmed !== "null" ? trimmed : null
+
+  await execAdbShell(
+    serial,
+    `settings put system screen_off_timeout ${SUITE_SCREEN_OFF_TIMEOUT}`
+  )
+}
+
+export async function teardown(): Promise<void> {
+  if (!serial) return
+
+  if (previousScreenOffTimeout !== null) {
+    await tryShell(`settings put system screen_off_timeout ${previousScreenOffTimeout}`)
+  }
+
+  // Leave the device awake and unlocked, whichever file happened to run last.
+  await tryShell("input keyevent KEYCODE_WAKEUP")
+  await tryShell("wm dismiss-keyguard")
+
+  // Deliberately NOT restoring USB transport here. `adb usb` restarts adbd, and
+  // on some devices it comes back unauthorized — requiring someone to physically
+  // accept the USB-debugging dialog before any further run works. Only the Wi-Fi
+  // tests switch the transport, and they are opt-in via TEST_WIFI=1, so that
+  // undo lives in wifi.test.ts where it is actually needed.
+}

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -40,9 +40,20 @@ export async function teardown(): Promise<void> {
 
   if (previousScreenOffTimeout !== null) {
     await tryShell(`settings put system screen_off_timeout ${previousScreenOffTimeout}`)
+  } else {
+    // The key was unset before the run, so writing SUITE_SCREEN_OFF_TIMEOUT
+    // created it. Removing it is the actual restore — leaving it behind would
+    // pin the device at a 10-minute timeout forever.
+    await tryShell("settings delete system screen_off_timeout")
   }
 
-  // Leave the device awake and unlocked, whichever file happened to run last.
+  // Leave the display awake, whichever file happened to run last. The keyguard
+  // is only best-effort: `wm dismiss-keyguard` exits 0 either way, but it is a
+  // no-op against a *secure* keyguard (one with a PIN/pattern/password), which
+  // it cannot dismiss without the user's credential — and should not. So on a
+  // secured device the suite hands the phone back awake but locked. That is
+  // fine: the suite is verified to pass from a locked start, since every file's
+  // beforeAll wakes the screen and the tools it exercises work behind the lock.
   await tryShell("input keyevent KEYCODE_WAKEUP")
   await tryShell("wm dismiss-keyguard")
 

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -9,15 +9,46 @@ const SUITE_SCREEN_OFF_TIMEOUT = "600000"
 
 let serial: string | null = null
 let previousScreenOffTimeout: string | null = null
+const cleanupFailures: { command: string; error: unknown }[] = []
 
-/** Run an adb shell command, swallowing failures so one broken step can't mask the rest. */
+/**
+ * Run an adb shell command, deferring failures so one broken step can't skip the
+ * ones after it. Every failure is still reported — see reportCleanupFailures().
+ */
 async function tryShell(command: string): Promise<void> {
   if (!serial) return
   try {
     await execAdbShell(serial, command)
-  } catch {
-    // best effort — teardown must keep going
+  } catch (error) {
+    cleanupFailures.push({ command, error })
   }
+}
+
+/**
+ * Fail the run if teardown could not put the device back. Silently swallowing
+ * these would let a green suite hand back a phone still pinned to the suite's
+ * settings — the next run then starts from a state nobody chose.
+ */
+function reportCleanupFailures(): void {
+  if (cleanupFailures.length === 0) return
+
+  const summary = cleanupFailures
+    .map(({ command, error }) => `  - ${command}: ${(error as Error).message}`)
+    .join("\n")
+
+  // Vitest prints a throw from globalSetup teardown as "error during close" but
+  // still exits 0, so the throw alone would leave CI green. Setting the exit code
+  // is what actually fails the run; the throw is what makes the cause readable.
+  process.exitCode = 1
+  throw new Error(
+    `Integration teardown could not restore the device (${cleanupFailures.length} command(s) failed); it may be left in a modified state:\n${summary}`,
+    {
+      cause:
+        cleanupFailures.length === 1
+          ? cleanupFailures[0].error
+          : new AggregateError(cleanupFailures.map(({ error }) => error)),
+    }
+  )
 }
 
 export async function setup(): Promise<void> {
@@ -62,4 +93,6 @@ export async function teardown(): Promise<void> {
   // accept the USB-debugging dialog before any further run works. Only the Wi-Fi
   // tests switch the transport, and they are opt-in via TEST_WIFI=1, so that
   // undo lives in wifi.test.ts where it is actually needed.
+
+  reportCleanupFailures()
 }

--- a/tests/integration/input.test.ts
+++ b/tests/integration/input.test.ts
@@ -10,17 +10,11 @@ describe("Input Tools Integration", () => {
     await disconnectClient()
   })
 
-  describe("screen_on / screen_off", () => {
+  describe("screen_on", () => {
     it("should turn screen on", async () => {
       const result = await callTool("screen_on")
       const text = String(parseResult(result))
       expect(text).toContain("on")
-    })
-
-    it("should turn screen off", async () => {
-      const result = await callTool("screen_off")
-      const text = String(parseResult(result))
-      expect(text).toContain("off")
     })
   })
 
@@ -57,6 +51,53 @@ describe("Input Tools Integration", () => {
       })
       const text = String(parseResult(result))
       expect(text).toContain("Swiped")
+    })
+  })
+
+  describe("long_press", () => {
+    it("should long press at coordinates", async () => {
+      const result = await callTool("long_press", { x: 500, y: 500, duration: 500 })
+      const text = String(parseResult(result))
+      expect(text).toContain("Long pressed")
+      expect(text).toContain("500")
+    })
+  })
+
+  describe("drag_drop", () => {
+    it("should perform a drag and drop gesture", async () => {
+      const result = await callTool("drag_drop", {
+        startX: 100,
+        startY: 500,
+        endX: 100,
+        endY: 200,
+        duration: 300,
+      })
+      const text = String(parseResult(result))
+      expect(text).toContain("Dragged")
+    })
+  })
+
+  describe("input_text", () => {
+    it("should type text into the focused field", async () => {
+      // Go HOME first so the launcher holds focus and the text cannot land in
+      // some real app's text field left focused by an earlier test. This is a
+      // round-trip smoke test of the tool only: it deliberately does not assert
+      // that the keystrokes reached the device, since there is no text field to
+      // read them back from.
+      await callTool("key_event", { keycode: "HOME" })
+
+      const result = await callTool("input_text", { text: "scrcpy-mcp-test" })
+      const text = String(parseResult(result))
+      expect(text).toContain("Typed:")
+      expect(text).toContain("scrcpy-mcp-test")
+    })
+  })
+
+  describe("scroll", () => {
+    it("should scroll at coordinates", async () => {
+      const result = await callTool("scroll", { x: 500, y: 500, dx: 0, dy: -1 })
+      const text = String(parseResult(result))
+      expect(text).toContain("Scrolled")
     })
   })
 })

--- a/tests/integration/mcp-client.ts
+++ b/tests/integration/mcp-client.ts
@@ -13,12 +13,24 @@ export async function connectClient(): Promise<Client> {
     args: [process.cwd() + "/dist/index.js"],
   })
 
-  client = new Client(
+  const c = new Client(
     { name: "test-client", version: "1.0.0" },
     { capabilities: {} }
   )
 
-  await client.connect(transport)
+  await c.connect(transport)
+
+  // Not just a warm-up: the SDK only caches output-schema validators in
+  // cacheToolMetadata(), which runs off listTools(). Without this call
+  // Client.callTool() skips validation entirely, so every tool declaring an
+  // outputSchema could return no structuredContent — or content that violates
+  // its own schema — and the suite would never notice. With it, every callTool
+  // in the suite asserts schema conformance for free.
+  await c.listTools()
+
+  // Published only once fully ready, so a caller can never observe a client
+  // whose validators have not been cached yet.
+  client = c
   return client
 }
 

--- a/tests/integration/mcp-client.ts
+++ b/tests/integration/mcp-client.ts
@@ -1,3 +1,4 @@
+import { expect } from "vitest"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
@@ -54,6 +55,47 @@ export async function callTool(name: string, args: Record<string, unknown> = {})
 export async function listTools() {
   const c = await connectClient()
   return c.listTools()
+}
+
+/**
+ * Stop any running scrcpy session, failing loudly if the tool reports an error.
+ *
+ * stop_session is a no-op when nothing is running, so calling it unconditionally
+ * is safe. A genuine failure, though, comes back as a *resolved* result carrying
+ * `isError` — a bare try/catch never sees it. Worth surfacing: the device permits
+ * one encoder session at a time, so a swallowed failure resurfaces much later as
+ * some unrelated file's start_session refusing to connect.
+ */
+export async function stopSessionOrFail(): Promise<void> {
+  const result = await callTool("stop_session")
+  if (!result.isError) return
+
+  const { message } = parseResult(result) as { message?: string }
+  throw new Error(`stop_session failed: ${message ?? JSON.stringify(result.content)}`)
+}
+
+/**
+ * Assert that an action tool succeeded, and hand back its structured payload.
+ *
+ * The action tools (rotate_device, screen_off, collapse_panels, …) put a bare
+ * human-readable sentence in `content` and report the actual contract — `success`
+ * — only in `structuredContent`. So matching a substring of the text says nothing
+ * about whether the action reported success; assert the structured payload and
+ * match the message from there instead.
+ *
+ * Schema validation (see connectClient) already rejects a malformed
+ * `structuredContent`, but it does not run for `isError` results and never checks
+ * that `success` is actually `true` — which is what these callers care about.
+ */
+export function expectActionOk(result: CallToolResult): { success: boolean; message: string } {
+  expect(result.isError, `tool returned an error: ${JSON.stringify(result.content)}`).toBeFalsy()
+
+  const data = result.structuredContent as { success?: boolean; message?: string } | undefined
+  expect(data, "action tool returned no structuredContent").toBeDefined()
+  expect(data!.success, `action reported failure: ${data!.message}`).toBe(true)
+  expect(typeof data!.message).toBe("string")
+
+  return data as { success: boolean; message: string }
 }
 
 export function parseResult(result: CallToolResult): unknown {

--- a/tests/integration/session.test.ts
+++ b/tests/integration/session.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest"
 import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
 
 describe("Session Tools Integration", () => {
+  // Set while the display is toggled away from its original orientation.
+  let isRotated = false
+
   beforeAll(async () => {
     await connectClient()
   }, 30000)
 
   afterAll(async () => {
+    if (isRotated) {
+      try {
+        await callTool("rotate_device")
+      } catch {
+        // Best effort — leave the device upright if we can
+      }
+    }
     try {
       await callTool("stop_session")
     } catch {
@@ -48,6 +58,38 @@ describe("Session Tools Integration", () => {
       const imageContent = result.content.find((c) => c.type === "image")
       expect(imageContent).toBeDefined()
     }, 15000)
+
+    it("should rotate the device", async () => {
+      // rotate_device toggles, so a second call restores the original
+      // orientation. Without it the rest of the suite — and the user's phone
+      // once the run ends — is left sideways. The flag keeps that true even if
+      // the assertion below throws, since afterAll then does the undo.
+      await callTool("rotate_device").then((result) => {
+        isRotated = true
+        expect(String(parseResult(result))).toContain("rotated")
+      })
+
+      await callTool("rotate_device")
+      isRotated = false
+    })
+
+    it("should expand the notification panel", async () => {
+      const result = await callTool("expand_notifications")
+      const text = String(parseResult(result))
+      expect(text).toContain("Notification panel expanded")
+    })
+
+    it("should expand the quick settings panel", async () => {
+      const result = await callTool("expand_settings")
+      const text = String(parseResult(result))
+      expect(text).toContain("Quick settings panel expanded")
+    })
+
+    it("should collapse panels", async () => {
+      const result = await callTool("collapse_panels")
+      const text = String(parseResult(result))
+      expect(text).toContain("Panels collapsed")
+    })
 
     it("should stop the session", async () => {
       const result = await callTool("stop_session")

--- a/tests/integration/session.test.ts
+++ b/tests/integration/session.test.ts
@@ -17,6 +17,14 @@ describe("Session Tools Integration", () => {
         // Best effort — leave the device upright if we can
       }
     }
+    // The expand_notifications / expand_settings tests leave a panel open if the
+    // collapse_panels test never runs, so collapse unconditionally rather than
+    // relying on that test having executed.
+    try {
+      await callTool("collapse_panels")
+    } catch {
+      // Best effort
+    }
     try {
       await callTool("stop_session")
     } catch {
@@ -64,10 +72,9 @@ describe("Session Tools Integration", () => {
       // orientation. Without it the rest of the suite — and the user's phone
       // once the run ends — is left sideways. The flag keeps that true even if
       // the assertion below throws, since afterAll then does the undo.
-      await callTool("rotate_device").then((result) => {
-        isRotated = true
-        expect(String(parseResult(result))).toContain("rotated")
-      })
+      const result = await callTool("rotate_device")
+      isRotated = true
+      expect(String(parseResult(result))).toContain("rotated")
 
       await callTool("rotate_device")
       isRotated = false

--- a/tests/integration/session.test.ts
+++ b/tests/integration/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
-import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+import { connectClient, disconnectClient, callTool, parseResult, expectActionOk, stopSessionOrFail } from "./mcp-client.js"
 
 describe("Session Tools Integration", () => {
   // Set while the display is toggled away from its original orientation.
@@ -25,12 +25,13 @@ describe("Session Tools Integration", () => {
     } catch {
       // Best effort
     }
+    // Disconnect in a finally so a failed stop still tears the server down —
+    // otherwise the stdio child outlives the run and vitest hangs on it.
     try {
-      await callTool("stop_session")
-    } catch {
-      // Ignore if no session
+      await stopSessionOrFail()
+    } finally {
+      await disconnectClient()
     }
-    await disconnectClient()
   }, 30000)
 
   // Tests are order-dependent: start_session must run before screenshot, and stop_session must run last
@@ -74,7 +75,7 @@ describe("Session Tools Integration", () => {
       // the assertion below throws, since afterAll then does the undo.
       const result = await callTool("rotate_device")
       isRotated = true
-      expect(String(parseResult(result))).toContain("rotated")
+      expect(expectActionOk(result).message).toContain("rotated")
 
       await callTool("rotate_device")
       isRotated = false
@@ -82,20 +83,17 @@ describe("Session Tools Integration", () => {
 
     it("should expand the notification panel", async () => {
       const result = await callTool("expand_notifications")
-      const text = String(parseResult(result))
-      expect(text).toContain("Notification panel expanded")
+      expect(expectActionOk(result).message).toContain("Notification panel expanded")
     })
 
     it("should expand the quick settings panel", async () => {
       const result = await callTool("expand_settings")
-      const text = String(parseResult(result))
-      expect(text).toContain("Quick settings panel expanded")
+      expect(expectActionOk(result).message).toContain("Quick settings panel expanded")
     })
 
     it("should collapse panels", async () => {
       const result = await callTool("collapse_panels")
-      const text = String(parseResult(result))
-      expect(text).toContain("Panels collapsed")
+      expect(expectActionOk(result).message).toContain("Panels collapsed")
     })
 
     it("should stop the session", async () => {

--- a/tests/integration/shell.test.ts
+++ b/tests/integration/shell.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+describe("Shell and Version Tools Integration", () => {
+  beforeAll(async () => {
+    await connectClient()
+  }, 30000)
+
+  afterAll(async () => {
+    await disconnectClient()
+  })
+
+  describe("shell_exec", () => {
+    it("should execute a shell command and return output", async () => {
+      const result = await callTool("shell_exec", {
+        command: "echo 'scrcpy-mcp-shell-test'",
+      })
+      const output = String(parseResult(result))
+
+      expect(output).toContain("scrcpy-mcp-shell-test")
+    })
+  })
+
+  describe("version", () => {
+    it("should report the scrcpy version", async () => {
+      const result = await callTool("version")
+      const output = String(parseResult(result))
+
+      expect(output).toContain("source:")
+      expect(output.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/tests/integration/ui.test.ts
+++ b/tests/integration/ui.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+describe("UI Tools Integration", () => {
+  beforeAll(async () => {
+    await connectClient()
+    await callTool("screen_on")
+  }, 30000)
+
+  afterAll(async () => {
+    await disconnectClient()
+  })
+
+  describe("ui_dump", () => {
+    it("should dump the current UI hierarchy as XML", async () => {
+      const result = await callTool("ui_dump")
+      const xml = String(parseResult(result))
+
+      expect(xml.length).toBeGreaterThan(0)
+      expect(xml.startsWith("<")).toBe(true)
+      expect(xml).toContain("node")
+    })
+  })
+
+  describe("ui_find_element", () => {
+    it("should find FrameLayout nodes on the screen", async () => {
+      const result = await callTool("ui_find_element", {
+        className: "android.widget.FrameLayout",
+      })
+      const parsed = parseResult(result) as {
+        count: number
+        elements: Array<{
+          className: string
+          tapX: number
+          tapY: number
+          clickable: boolean
+        }>
+      }
+
+      expect(parsed.count).toBeGreaterThan(0)
+      expect(parsed.elements.length).toBe(parsed.count)
+      expect(parsed.elements[0]).toHaveProperty("tapX")
+      expect(parsed.elements[0]).toHaveProperty("tapY")
+    })
+  })
+})

--- a/tests/integration/wifi.test.ts
+++ b/tests/integration/wifi.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { execAdb } from "../../src/utils/adb.js"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+const runWifiTests = process.env.TEST_WIFI === "1"
+
+describe.skipIf(!runWifiTests)("Wi-Fi ADB Tools Integration", () => {
+  let deviceSerial: string | null = null
+  let wifiAddress: string | null = null
+
+  beforeAll(async () => {
+    await connectClient()
+    const result = await callTool("device_list")
+    const parsed = parseResult(result) as {
+      devices: Array<{ serial: string }>
+    }
+    deviceSerial = parsed.devices[0]?.serial ?? null
+  }, 30000)
+
+  afterAll(async () => {
+    if (wifiAddress) {
+      try {
+        await callTool("disconnect_wifi", { address: wifiAddress })
+      } catch {
+        // ignore
+      }
+    }
+    // disconnect_wifi only drops the host-side TCP connection; connect_wifi ran
+    // `adb tcpip`, which leaves adbd on the device listening indefinitely, so
+    // put it back on USB-only transport. Gated on connect_wifi having actually
+    // succeeded: `adb usb` restarts adbd, and on some devices it returns
+    // unauthorized until someone accepts the USB-debugging dialog on the phone.
+    // That is an acceptable cost to undo a transport switch we caused, but not
+    // one to pay on every run of the suite.
+    if (wifiAddress && deviceSerial) {
+      try {
+        await execAdb(["-s", deviceSerial, "usb"])
+      } catch {
+        // ignore
+      }
+    }
+    await disconnectClient()
+  }, 30000)
+
+  it("should connect to and disconnect from the device over Wi-Fi", async () => {
+    expect(deviceSerial).toBeTruthy()
+
+    const connectResult = await callTool("connect_wifi", {
+      serial: deviceSerial!,
+      port: 5555,
+    })
+    const connectMessage = String(parseResult(connectResult))
+    expect(connectResult.isError || connectMessage.toLowerCase().includes("failed")).toBe(false)
+    expect(connectMessage).toContain("Connected to")
+
+    const addressMatch = connectMessage.match(/Connected to\s+([\d.:]+)/)
+    expect(addressMatch).toBeTruthy()
+    wifiAddress = addressMatch![1]
+
+    const disconnectResult = await callTool("disconnect_wifi", { address: wifiAddress })
+    const disconnectMessage = String(parseResult(disconnectResult))
+    expect(disconnectResult.isError || disconnectMessage.toLowerCase().includes("failed")).toBe(false)
+    expect(disconnectMessage).toContain("Disconnected")
+  }, 60000)
+})

--- a/tests/integration/z-screen-lock.test.ts
+++ b/tests/integration/z-screen-lock.test.ts
@@ -12,8 +12,11 @@ describe("Screen Lock Tool Integration", () => {
   }, 30000)
 
   afterAll(async () => {
-    // KEYCODE_WAKEUP alone wakes the display but leaves the keyguard up, so
-    // dismiss it explicitly.
+    // screen_on alone wakes the display but leaves the keyguard up, so try to
+    // dismiss it too. On a device with a PIN/pattern/password this cannot
+    // succeed — `wm dismiss-keyguard` still exits 0 — and the device stays
+    // locked for the rest of the run. Every other file's beforeAll wakes the
+    // screen and its tools work behind the lock, so that is not fatal.
     try {
       await callTool("screen_on")
       await callTool("shell_exec", { command: "wm dismiss-keyguard" })

--- a/tests/integration/z-screen-lock.test.ts
+++ b/tests/integration/z-screen-lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
-import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+import { connectClient, disconnectClient, callTool, expectActionOk } from "./mcp-client.js"
 
 // Turning the screen off locks most devices, which would break every later
 // file. Do NOT rely on the filename to defer this: Vitest's BaseSequencer
@@ -29,8 +29,7 @@ describe("Screen Lock Tool Integration", () => {
   describe("screen_off", () => {
     it("should turn screen off", async () => {
       const result = await callTool("screen_off")
-      const text = String(parseResult(result))
-      expect(text).toContain("off")
+      expect(expectActionOk(result).message).toContain("off")
     })
   })
 })

--- a/tests/integration/z-screen-lock.test.ts
+++ b/tests/integration/z-screen-lock.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import { connectClient, disconnectClient, callTool, parseResult } from "./mcp-client.js"
+
+// Turning the screen off locks most devices, which would break every later
+// file. Do NOT rely on the filename to defer this: Vitest's BaseSequencer
+// orders files by previous failure, then duration, then size — never by name —
+// so this file can run first. It restores the screen itself instead, which
+// makes the ordering irrelevant.
+describe("Screen Lock Tool Integration", () => {
+  beforeAll(async () => {
+    await connectClient()
+  }, 30000)
+
+  afterAll(async () => {
+    // KEYCODE_WAKEUP alone wakes the display but leaves the keyguard up, so
+    // dismiss it explicitly.
+    try {
+      await callTool("screen_on")
+      await callTool("shell_exec", { command: "wm dismiss-keyguard" })
+    } catch {
+      // ignore
+    }
+    await disconnectClient()
+  }, 30000)
+
+  describe("screen_off", () => {
+    it("should turn screen off", async () => {
+      const result = await callTool("screen_off")
+      const text = String(parseResult(result))
+      expect(text).toContain("off")
+    })
+  })
+})

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     include: ["tests/integration/**/*.test.ts"],
+    // One physical device, so files must not compete for it.
+    fileParallelism: false,
+    // Snapshots and restores device state that outlives any single file.
+    globalSetup: ["tests/integration/global-setup.ts"],
     testTimeout: 60000,
     hookTimeout: 60000,
     teardownTimeout: 30000,


### PR DESCRIPTION
Add comprehensive integration tests covering app management, clipboard, file push/pull/list, shell and version commands, UI hierarchy dumps, Wi-Fi ADB transport, and screen lock behavior. Tests run sequentially against a single physical device (fileParallelism: false) with a global setup that keeps the screen alive and restores the original screen-off timeout after the run.

Fix two production bugs surfaced while writing the tests:

- apps.ts: loosen the mResumedActivity regex to also match the bare "ResumedActivity" line printed by Android builds that drop the "m" prefix, and explicitly anchor on the "u\d+" user field so the package name capture group lands on the right token.
- files.ts: pass -H (not -L) to ls in file_list so a symlinked directory such as /sdcard lists its target contents. -L would dereference every entry, and a single dangling symlink makes ls exit 1, turning the whole directory listing into a tool error.