### PR TITLE
fix: detect the scrcpy server version and stop dropping clipboard acks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add to `.vscode/mcp.json`:
 
 ### Customizing Environment Variables
 
-If you need to configure custom options (such as pointing to a non-standard `scrcpy-server` path or forcing a specific version), you can add the `"env"` object to your server configuration. For example:
+If you need to configure custom options (such as pointing to a non-standard `scrcpy-server` path), you can add the `"env"` object to your server configuration. For example:
 
 ```json
 {
@@ -140,13 +140,14 @@ If you need to configure custom options (such as pointing to a non-standard `scr
       "command": "npx",
       "args": ["scrcpy-mcp"],
       "env": {
-        "SCRCPY_SERVER_PATH": "C:\\path\\to\\scrcpy-server",
-        "SCRCPY_SERVER_VERSION": "3.3.4"
+        "SCRCPY_SERVER_PATH": "C:\\path\\to\\scrcpy-server"
       }
     }
   }
 }
 ```
+
+*Note: only set `SCRCPY_SERVER_VERSION` if version auto-detection fails — it overrides detection, so a stale value causes the version mismatch described in [Troubleshooting](#troubleshooting). Match it to your installed scrcpy (`scrcpy --version`).*
 
 *Note: On Windows, remember to double-escape backslashes (`\\`) in your configuration paths.*
 
@@ -271,10 +272,10 @@ When only one device is connected, tools auto-detect it. With multiple devices, 
 Accept the RSA fingerprint prompt on the device. If the prompt doesn't appear, revoke USB debugging authorizations in Developer Options and reconnect.
 
 **`start_session` fails**
-Make sure scrcpy is installed and the `scrcpy-server` binary is accessible. Set `SCRCPY_SERVER_PATH` if it's in a non-standard location.
+Make sure scrcpy is installed and the `scrcpy-server` binary is accessible. On Windows, add the folder containing both `scrcpy.exe` and `scrcpy-server` to your PATH, or set `SCRCPY_SERVER_PATH` to the full path of the `scrcpy-server` file.
 * **File vs Directory**: Ensure `SCRCPY_SERVER_PATH` points directly to the `scrcpy-server` **file** itself (e.g. `C:\path\to\scrcpy-server`), NOT to its parent folder.
 * **Android Directory Conflict**: If you previously pushed a directory to the server path, `/data/local/tmp/scrcpy-server.jar` on the Android device might have been created as a folder. Run `adb shell rm -rf /data/local/tmp/scrcpy-server.jar` to delete it.
-* **Version Mismatch**: Ensure `SCRCPY_SERVER_VERSION` matches the exact version of the `scrcpy-server` file (e.g., `"3.3.4"`). If they mismatch, the Android JVM will fail with `java.lang.ClassNotFoundException: com.genymobile.scrcpy.Server`.
+* **Version Mismatch**: The client must send the exact version of the `scrcpy-server` file. If version auto-detection fails (common on Windows or when the MCP is launched by a GUI app without your shell PATH), the client falls back to a default version and the server may exit with a version-mismatch error. Set `SCRCPY_SERVER_VERSION` to your installed version (e.g., `"4.1"`) as a workaround. See the Environment Variables table above.
 
 **Screenshots are slow (~500ms)**
 Start a scrcpy session with `start_session` to enable the fast video stream path. Requires scrcpy and ffmpeg.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,6 +38,10 @@ export const CONTROL_MSG_TYPE_START_APP = 16
 export const CONTROL_MSG_TYPE_RESET_VIDEO = 17
 
 export const DEVICE_MSG_TYPE_CLIPBOARD = 0
+export const DEVICE_MSG_TYPE_ACK_CLIPBOARD = 1
+
+/** ACK_CLIPBOARD is a fixed 9 bytes: the type byte plus a 64-bit sequence. */
+export const DEVICE_MSG_ACK_CLIPBOARD_SIZE = 9
 
 /**
  * Touch Event Actions

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -2,6 +2,7 @@ import { spawn, execFileSync, ChildProcess } from "child_process"
 import { createRequire } from "module"
 import * as net from "net"
 import * as path from "path"
+import { StringDecoder } from "string_decoder"
 import * as fs from "fs"
 import { execAdb, execAdbShell, resolveSerial, getScreenSize } from "./adb.js"
 import {
@@ -833,7 +834,13 @@ export function startScrcpyServer(
     stdio: ["ignore", "ignore", "pipe"],
   })
 
-  let stderrBuffer = ""
+  // Retained as raw bytes so the cap is actually a byte cap and so a multi-byte
+  // character straddling two chunks survives: decoding is deferred to the getter,
+  // which sees the whole buffer at once.
+  let stderrBuffer = Buffer.alloc(0)
+  // Separate decoder for the live log lines, which are emitted per chunk and so
+  // would otherwise mangle a character split across a chunk boundary.
+  const stderrDecoder = new StringDecoder("utf8")
   let exitInfo: ServerExit | null = null
 
   child.once("exit", (code, signal) => {
@@ -842,12 +849,13 @@ export function startScrcpyServer(
 
   if (child.stderr) {
     child.stderr.on("data", (data: Buffer) => {
-      const text = data.toString()
-      stderrBuffer += text
+      stderrBuffer = Buffer.concat([stderrBuffer, data])
       if (stderrBuffer.length > MAX_SERVER_STDERR_BYTES) {
-        stderrBuffer = stderrBuffer.slice(-MAX_SERVER_STDERR_BYTES)
+        stderrBuffer = stderrBuffer.subarray(
+          stderrBuffer.length - MAX_SERVER_STDERR_BYTES
+        )
       }
-      const msg = text.trim()
+      const msg = stderrDecoder.write(data).trim()
       if (msg) {
         console.error(`[scrcpy-server] ${msg}`)
       }
@@ -866,7 +874,7 @@ export function startScrcpyServer(
       child.unref()
       resolve({
         process: child,
-        get stderr() { return stderrBuffer },
+        get stderr() { return stderrBuffer.toString("utf8") },
         get exit() { return exitInfo },
       })
     })

--- a/src/utils/scrcpy.ts
+++ b/src/utils/scrcpy.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync, ChildProcess } from "child_process"
+import { spawn, execFileSync, ChildProcess } from "child_process"
 import { createRequire } from "module"
 import * as net from "net"
 import * as path from "path"
@@ -28,6 +28,8 @@ import {
   JPEG_SOI,
   JPEG_EOI,
   DEVICE_MSG_TYPE_CLIPBOARD,
+  DEVICE_MSG_TYPE_ACK_CLIPBOARD,
+  DEVICE_MSG_ACK_CLIPBOARD_SIZE,
   MAX_CLIPBOARD_BYTES,
   CLIPBOARD_COPY_KEY_NONE,
   DEVICE_META_SIZE,
@@ -502,10 +504,55 @@ function startVideoStream(
   return firstFramePromise
 }
 
+// Existence alone is not enough for either the scrcpy binary or the server: a
+// directory satisfies existsSync, and `adb push <dir>` then creates the remote
+// scrcpy-server.jar as a directory, which fails later with a confusing error.
+// Rejecting non-files here keeps that mistake local and legible.
+function isExistingFile(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile()
+  } catch {
+    return false
+  }
+}
+
+function findScrcpyBinaryOnPath(): string | null {
+  const command = process.platform === "win32" ? "where" : "which"
+  try {
+    const output = execFileSync(command, ["scrcpy"], {
+      encoding: "utf8",
+      timeout: 5000,
+    })
+    const lines = output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+    for (const line of lines) {
+      if (isExistingFile(line)) {
+        return line
+      }
+    }
+  } catch {
+    // scrcpy not on PATH or lookup failed
+  }
+  return null
+}
+
 export function findScrcpyServer(): string | null {
   const envPath = process.env.SCRCPY_SERVER_PATH
-  if (envPath && fs.existsSync(envPath)) {
+  if (envPath && isExistingFile(envPath)) {
     return envPath
+  }
+
+  // Try to discover the server next to the scrcpy executable on PATH. This
+  // matches how the official scrcpy client works and covers Windows zip
+  // installs where users add the scrcpy directory to PATH.
+  const scrcpyBinary = findScrcpyBinaryOnPath()
+  if (scrcpyBinary) {
+    const serverNextToBinary = path.join(path.dirname(scrcpyBinary), "scrcpy-server")
+    if (isExistingFile(serverNextToBinary)) {
+      return serverNextToBinary
+    }
   }
 
   const homeDir = process.env.HOME || process.env.USERPROFILE
@@ -519,7 +566,7 @@ export function findScrcpyServer(): string | null {
   }
 
   for (const p of commonPaths) {
-    if (fs.existsSync(p)) {
+    if (isExistingFile(p)) {
       return p
     }
   }
@@ -528,7 +575,7 @@ export function findScrcpyServer(): string | null {
 }
 
 // Memoized: the version cannot change mid-process, and the uncached form runs
-// a blocking execSync per call. Caching also guarantees every caller in a
+// a blocking execFileSync per call. Caching also guarantees every caller in a
 // session start sees the same version, so the server launch args and the
 // client's protocol expectations can never disagree.
 let cachedScrcpyVersion: DetectedVersion | null = null
@@ -552,7 +599,7 @@ export function computeScrcpyVersionInfo(): DetectedVersion {
   }
 
   try {
-    const output = execSync("scrcpy --version 2>/dev/null", {
+    const output = execFileSync("scrcpy", ["--version"], {
       timeout: 5000,
       encoding: "utf8",
     })
@@ -566,6 +613,12 @@ export function computeScrcpyVersionInfo(): DetectedVersion {
     // scrcpy CLI not available, fall through
   }
 
+  console.error(
+    `[scrcpy] Warning: could not detect scrcpy version from binary or ` +
+      `SCRCPY_SERVER_VERSION environment variable; falling back to default ` +
+      `${SCRCPY_SERVER_VERSION}. Set SCRCPY_SERVER_VERSION if the installed ` +
+      `server version differs.`
+  )
   return { version: SCRCPY_SERVER_VERSION, source: "default" }
 }
 
@@ -707,30 +760,101 @@ export function buildServerArgs(
   ]
 }
 
-export async function startScrcpyServer(
+// Cap on the retained server stderr tail. The adb child lives for the whole
+// session and the server runs at log_level=verbose, so an uncapped buffer would
+// grow without bound while only ever being read on connect failure. The errors
+// worth surfacing (e.g. a version mismatch) are the last thing written before
+// the server dies, so keeping the tail loses nothing.
+const MAX_SERVER_STDERR_BYTES = 8192
+
+export interface ServerExit {
+  code: number | null
+  signal: NodeJS.Signals | null
+}
+
+export interface ScrcpyServerProcess {
+  process: ChildProcess
+  // Stderr emitted by the server process since spawn, truncated to the last
+  // MAX_SERVER_STDERR_BYTES. Collected so it can be surfaced in
+  // connection-timeout errors when the server exits immediately (e.g. due to a
+  // version mismatch).
+  stderr: string
+  // Set once the adb child exits. The scrcpy server runs in the foreground of
+  // that adb shell, so an exit before the client connects means the server died
+  // (e.g. version mismatch) and no amount of retrying will reach it.
+  exit: ServerExit | null
+}
+
+/**
+ * Build the error for a session whose server never accepted a connection. Pure
+ * so the diagnostics that matter here — the server's own stderr, and whether it
+ * died rather than timed out — can be tested without standing up adb, port
+ * forwarding, and sockets.
+ */
+export function formatConnectFailure(
+  port: number,
+  timeoutMs: number,
+  server: Pick<ScrcpyServerProcess, "stderr" | "exit">
+): string {
+  const lines: string[] = []
+
+  if (server.exit) {
+    const how = server.exit.signal
+      ? `signal ${server.exit.signal}`
+      : `exit code ${server.exit.code}`
+    lines.push(
+      `The scrcpy server exited (${how}) before accepting a connection on port ${port}.`
+    )
+  } else {
+    lines.push(
+      `Failed to connect to scrcpy server on port ${port} within ${timeoutMs}ms`
+    )
+  }
+
+  const serverStderr = server.stderr.trim()
+  if (serverStderr) {
+    lines.push(`Server stderr:\n${serverStderr}`)
+  }
+
+  return lines.join("\n")
+}
+
+export function startScrcpyServer(
   serial: string,
   scid: number,
   options: ScrcpySessionOptions = {}
-): Promise<void> {
+): Promise<ScrcpyServerProcess> {
   const version = detectScrcpyVersion()
   console.error(`[scrcpy] Using scrcpy server version: ${version}`)
   const serverArgs = buildServerArgs(serial, scid, version, options)
 
-  return new Promise((resolve, reject) => {
-    const child = spawn(ADB_PATH, serverArgs, {
-      detached: true,
-      stdio: ["ignore", "ignore", "pipe"],
+  const child = spawn(ADB_PATH, serverArgs, {
+    detached: true,
+    stdio: ["ignore", "ignore", "pipe"],
+  })
+
+  let stderrBuffer = ""
+  let exitInfo: ServerExit | null = null
+
+  child.once("exit", (code, signal) => {
+    exitInfo = { code, signal }
+  })
+
+  if (child.stderr) {
+    child.stderr.on("data", (data: Buffer) => {
+      const text = data.toString()
+      stderrBuffer += text
+      if (stderrBuffer.length > MAX_SERVER_STDERR_BYTES) {
+        stderrBuffer = stderrBuffer.slice(-MAX_SERVER_STDERR_BYTES)
+      }
+      const msg = text.trim()
+      if (msg) {
+        console.error(`[scrcpy-server] ${msg}`)
+      }
     })
+  }
 
-    if (child.stderr) {
-      child.stderr.on("data", (data: Buffer) => {
-        const msg = data.toString().trim()
-        if (msg) {
-          console.error(`[scrcpy-server] ${msg}`)
-        }
-      })
-    }
-
+  return new Promise((resolve, reject) => {
     child.once("error", (err) => {
       reject(new Error(
         `Failed to start scrcpy server for ${serial}: ${err.message}`,
@@ -740,7 +864,11 @@ export async function startScrcpyServer(
 
     child.once("spawn", () => {
       child.unref()
-      resolve()
+      resolve({
+        process: child,
+        get stderr() { return stderrBuffer },
+        get exit() { return exitInfo },
+      })
     })
   })
 }
@@ -900,42 +1028,92 @@ const receiveDeviceMeta = async (
     socket.resume()
   })
 
+export interface DeviceMessageHandlers {
+  /** Called once per complete clipboard message, in arrival order. */
+  onClipboard: (text: string) => void
+  /** Called when the stream can no longer be framed; the buffer is dropped. */
+  onError: (message: string) => void
+}
+
+/**
+ * Parse whatever complete device messages `pending + chunk` contains, returning
+ * the bytes left over — the head of a message whose tail has not arrived yet.
+ *
+ * Framing is the entire job here: messages are not aligned to TCP reads, so one
+ * read can carry several messages, a fraction of one, or both. Each type is
+ * therefore consumed by its own exact length, and a type that is recognised but
+ * ignored still has to be measured, because the bytes after it are a real
+ * message.
+ *
+ * Pure apart from the handlers, so those rules can be tested by feeding buffers
+ * in rather than by driving a device.
+ */
+export function consumeDeviceMessages(
+  pending: Buffer,
+  chunk: Buffer,
+  handlers: DeviceMessageHandlers
+): Buffer {
+  let buffer = Buffer.concat([pending, chunk])
+
+  // One byte is enough to learn the type; each branch then waits for the rest of
+  // its own message.
+  while (buffer.length >= 1) {
+    const msgType = buffer.readUInt8(0)
+
+    if (msgType === DEVICE_MSG_TYPE_CLIPBOARD) {
+      if (buffer.length < 5) break
+
+      const textLength = buffer.readUInt32BE(1)
+
+      if (textLength > MAX_CLIPBOARD_BYTES) {
+        handlers.onError(
+          `Clipboard payload too large: ${textLength} bytes ` +
+            `(max ${MAX_CLIPBOARD_BYTES}), resetting buffer`
+        )
+        return Buffer.alloc(0)
+      }
+
+      if (buffer.length < 5 + textLength) break
+
+      handlers.onClipboard(buffer.toString("utf8", 5, 5 + textLength))
+      buffer = buffer.subarray(5 + textLength)
+    } else if (msgType === DEVICE_MSG_TYPE_ACK_CLIPBOARD) {
+      // The server acknowledges every SET_CLIPBOARD sent with a non-zero
+      // sequence. setClipboardViaScrcpy is fire-and-forget, so the sequence is
+      // of no use to us — but skipping the ack by its exact length is not
+      // optional. Treating it as unparseable used to drop the whole buffer,
+      // which discards any clipboard message that arrived in the same read.
+      if (buffer.length < DEVICE_MSG_ACK_CLIPBOARD_SIZE) break
+
+      buffer = buffer.subarray(DEVICE_MSG_ACK_CLIPBOARD_SIZE)
+    } else {
+      // Length is encoded per type, so an unrecognised type leaves nothing to
+      // say where the next message starts. Dropping the buffer is the only
+      // resync available.
+      handlers.onError(`Unknown device message type: ${msgType}, resetting buffer`)
+      return Buffer.alloc(0)
+    }
+  }
+
+  return buffer
+}
+
 const startDeviceMessageHandler = (session: ScrcpySession): void => {
   if (!session.controlSocket) return
 
-  let messageBuffer = Buffer.alloc(0)
+  // Annotated because Buffer.alloc infers the narrower Buffer<ArrayBuffer>,
+  // which the parser's return type does not satisfy.
+  let messageBuffer: Buffer = Buffer.alloc(0)
 
   session.controlSocket.on("data", (data: Buffer) => {
-    messageBuffer = Buffer.concat([messageBuffer, data])
-
-    while (messageBuffer.length >= 5) {
-      const msgType = messageBuffer.readUInt8(0)
-
-      if (msgType === DEVICE_MSG_TYPE_CLIPBOARD) {
-        const textLength = messageBuffer.readUInt32BE(1)
-
-        if (textLength > MAX_CLIPBOARD_BYTES) {
-          console.error(
-            `[scrcpy] [${session.serial}] Clipboard payload too large: ` +
-              `${textLength} bytes (max ${MAX_CLIPBOARD_BYTES}), resetting buffer`
-          )
-          messageBuffer = Buffer.alloc(0)
-          break
-        }
-
-        if (messageBuffer.length < 5 + textLength) break
-
-        const text = messageBuffer.toString("utf8", 5, 5 + textLength)
+    messageBuffer = consumeDeviceMessages(messageBuffer, data, {
+      onClipboard: (text) => {
         session.clipboardContent = text
-
-        messageBuffer = messageBuffer.subarray(5 + textLength)
-      } else {
-        console.error(
-          `[scrcpy] [${session.serial}] Unknown device message type: ${msgType}, resetting buffer`
-        )
-        messageBuffer = Buffer.alloc(0)
-      }
-    }
+      },
+      onError: (message) => {
+        console.error(`[scrcpy] [${session.serial}] ${message}`)
+      },
+    })
   })
 }
 
@@ -962,8 +1140,9 @@ export async function startSession(
   const scid = generateScid()
   await setupPortForwarding(s, port, scid)
 
+  let serverProcess: ScrcpyServerProcess
   try {
-    await startScrcpyServer(s, scid, options)
+    serverProcess = await startScrcpyServer(s, scid, options)
   } catch (err) {
     await removePortForwarding(s, port)
     throw err
@@ -988,6 +1167,12 @@ export async function startSession(
       break
     } catch (err) {
       lastError = err as Error
+      // The adb child is gone, so the server it was running is gone too.
+      // Retrying can only burn the rest of the timeout before reporting a
+      // failure we already know about.
+      if (serverProcess.exit) {
+        break
+      }
       await new Promise((resolve) => setTimeout(resolve, retryInterval))
     }
   }
@@ -1004,7 +1189,7 @@ export async function startSession(
       // Ignore if forwarding doesn't exist
     }
     throw new Error(
-      `Failed to connect to scrcpy server on port ${port} within ${connectTimeout}ms`,
+      formatConnectFailure(port, connectTimeout, serverProcess),
       { cause: lastError }
     )
   }

--- a/tests/scrcpy-protocol.test.ts
+++ b/tests/scrcpy-protocol.test.ts
@@ -12,6 +12,7 @@ import {
   serializeSetClipboard,
   serializeRotateDevice,
   serializeStartApp,
+  consumeDeviceMessages,
 } from "../src/utils/scrcpy.js"
 import {
   CONTROL_MSG_TYPE_INJECT_KEYCODE as MSG_INJECT_KEYCODE,
@@ -26,6 +27,9 @@ import {
   CONTROL_MSG_TYPE_SET_DISPLAY_POWER as MSG_SET_DISPLAY_POWER,
   CONTROL_MSG_TYPE_ROTATE_DEVICE as MSG_ROTATE_DEVICE,
   CONTROL_MSG_TYPE_START_APP as MSG_START_APP,
+  DEVICE_MSG_TYPE_CLIPBOARD,
+  DEVICE_MSG_TYPE_ACK_CLIPBOARD,
+  MAX_CLIPBOARD_BYTES,
 } from "../src/utils/constants.js"
 
 describe("serializeInjectKeycode", () => {
@@ -334,5 +338,153 @@ describe("serializeStartApp", () => {
   it("accepts a package name of exactly 255 bytes", () => {
     const maxName = "com." + "a".repeat(251)
     expect(() => serializeStartApp(maxName)).not.toThrow()
+  })
+})
+
+describe("consumeDeviceMessages", () => {
+  const EMPTY = Buffer.alloc(0)
+
+  function clipboardMessage(text: string): Buffer {
+    const textBytes = Buffer.from(text, "utf8")
+    const buf = Buffer.alloc(5 + textBytes.length)
+    buf.writeUInt8(DEVICE_MSG_TYPE_CLIPBOARD, 0)
+    buf.writeUInt32BE(textBytes.length, 1)
+    textBytes.copy(buf, 5)
+    return buf
+  }
+
+  function ackMessage(sequence: bigint): Buffer {
+    const buf = Buffer.alloc(9)
+    buf.writeUInt8(DEVICE_MSG_TYPE_ACK_CLIPBOARD, 0)
+    buf.writeBigUInt64BE(sequence, 1)
+    return buf
+  }
+
+  function collector() {
+    const clipboard: string[] = []
+    const errors: string[] = []
+    return {
+      clipboard,
+      errors,
+      handlers: {
+        onClipboard: (text: string) => clipboard.push(text),
+        onError: (message: string) => errors.push(message),
+      },
+    }
+  }
+
+  it("skips an ack without reporting an error", () => {
+    const { clipboard, errors, handlers } = collector()
+
+    const rest = consumeDeviceMessages(EMPTY, ackMessage(BigInt(1)), handlers)
+
+    expect(errors).toEqual([])
+    expect(clipboard).toEqual([])
+    expect(rest.length).toBe(0)
+  })
+
+  it("keeps a clipboard message that shares a read with an ack", () => {
+    // The regression: an ack used to be unparseable, and the recovery for that
+    // dropped the whole buffer — taking the clipboard payload behind it with it,
+    // leaving clipboard_get to time out or return stale text.
+    const { clipboard, errors, handlers } = collector()
+
+    const rest = consumeDeviceMessages(
+      EMPTY,
+      Buffer.concat([ackMessage(BigInt(7)), clipboardMessage("copied text")]),
+      handlers
+    )
+
+    expect(errors).toEqual([])
+    expect(clipboard).toEqual(["copied text"])
+    expect(rest.length).toBe(0)
+  })
+
+  it("holds a split ack until the rest of it arrives", () => {
+    const { clipboard, errors, handlers } = collector()
+    const ack = ackMessage(BigInt(3))
+
+    const afterHead = consumeDeviceMessages(EMPTY, ack.subarray(0, 4), handlers)
+    expect(errors).toEqual([])
+    expect(afterHead.length).toBe(4)
+
+    const rest = consumeDeviceMessages(
+      afterHead,
+      Buffer.concat([ack.subarray(4), clipboardMessage("later")]),
+      handlers
+    )
+
+    expect(errors).toEqual([])
+    expect(clipboard).toEqual(["later"])
+    expect(rest.length).toBe(0)
+  })
+
+  it("delivers every clipboard message in a batched read", () => {
+    const { clipboard, handlers } = collector()
+
+    consumeDeviceMessages(
+      EMPTY,
+      Buffer.concat([
+        clipboardMessage("first"),
+        ackMessage(BigInt(1)),
+        clipboardMessage("second"),
+      ]),
+      handlers
+    )
+
+    expect(clipboard).toEqual(["first", "second"])
+  })
+
+  it("carries a partial clipboard message over to the next read", () => {
+    const { clipboard, handlers } = collector()
+    const message = clipboardMessage("split payload")
+
+    const rest = consumeDeviceMessages(EMPTY, message.subarray(0, 8), handlers)
+    expect(clipboard).toEqual([])
+
+    consumeDeviceMessages(rest, message.subarray(8), handlers)
+    expect(clipboard).toEqual(["split payload"])
+  })
+
+  it("preserves a lone type byte rather than treating it as truncated", () => {
+    const { errors, handlers } = collector()
+
+    const rest = consumeDeviceMessages(
+      EMPTY,
+      Buffer.from([DEVICE_MSG_TYPE_CLIPBOARD]),
+      handlers
+    )
+
+    expect(errors).toEqual([])
+    expect(rest.length).toBe(1)
+  })
+
+  it("drops the buffer on an unknown message type", () => {
+    // Nothing encodes the length of a type we do not know, so there is no way to
+    // find the next message boundary — the buffer has to go.
+    const { errors, handlers } = collector()
+
+    const rest = consumeDeviceMessages(
+      EMPTY,
+      Buffer.concat([Buffer.from([0x7f]), clipboardMessage("unreachable")]),
+      handlers
+    )
+
+    expect(errors).toEqual(["Unknown device message type: 127, resetting buffer"])
+    expect(rest.length).toBe(0)
+  })
+
+  it("drops the buffer when a clipboard payload exceeds the cap", () => {
+    const { clipboard, errors, handlers } = collector()
+    const oversized = Buffer.alloc(5)
+    oversized.writeUInt8(DEVICE_MSG_TYPE_CLIPBOARD, 0)
+    oversized.writeUInt32BE(MAX_CLIPBOARD_BYTES + 1, 1)
+
+    const rest = consumeDeviceMessages(EMPTY, oversized, handlers)
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain("Clipboard payload too large")
+    expect(clipboard).toEqual([])
+    expect(rest.length).toBe(0)
   })
 })

--- a/tests/scrcpy-version.test.ts
+++ b/tests/scrcpy-version.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
+import * as fs from "fs"
+import * as path from "path"
 import {
   buildServerArgs,
   videoMetaLayout,
+  findScrcpyServer,
+  formatConnectFailure,
   computeScrcpyVersionInfo,
   detectScrcpyVersionInfo,
   detectScrcpyVersion,
@@ -20,10 +24,41 @@ import {
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>()
-  return { ...actual, execSync: vi.fn() }
+  return { ...actual, execFileSync: vi.fn() }
 })
 
-const execSyncMock = vi.mocked(execSync)
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>()
+  return { ...actual, statSync: vi.fn() }
+})
+
+const execFileSyncMock = vi.mocked(execFileSync)
+const statSyncMock = vi.mocked(fs.statSync)
+
+// Discovery accepts a path only if it stats as a regular file, so tests declare
+// which paths are files; everything else stats as a directory or throws ENOENT.
+function mockFilesystem(files: string[], directories: string[] = []) {
+  statSyncMock.mockImplementation(((p: fs.PathLike) => {
+    const target = String(p)
+    if (files.includes(target)) {
+      return { isFile: () => true } as fs.Stats
+    }
+    if (directories.includes(target)) {
+      return { isFile: () => false } as fs.Stats
+    }
+    throw Object.assign(new Error(`ENOENT: no such file or directory, stat '${target}'`), {
+      code: "ENOENT",
+    })
+  }) as unknown as typeof fs.statSync)
+}
+
+// Both mocks replace module-wide functions, so reset them for every test in the
+// file rather than per-describe. A stale implementation leaking across describe
+// blocks surfaces as an unrelated test failing later, which is hard to trace.
+beforeEach(() => {
+  execFileSyncMock.mockReset()
+  statSyncMock.mockReset()
+})
 
 describe("buildServerArgs", () => {
   const commonWireFormatArgs = [
@@ -98,11 +133,162 @@ describe("videoMetaLayout", () => {
   })
 })
 
+describe("findScrcpyServer", () => {
+  const originalEnv = process.env.SCRCPY_SERVER_PATH
+
+  beforeEach(() => {
+    mockFilesystem([])
+    delete process.env.SCRCPY_SERVER_PATH
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.SCRCPY_SERVER_PATH
+    } else {
+      process.env.SCRCPY_SERVER_PATH = originalEnv
+    }
+  })
+
+  it("returns SCRCPY_SERVER_PATH env var when present", () => {
+    process.env.SCRCPY_SERVER_PATH = "/env/scrcpy-server"
+    mockFilesystem(["/env/scrcpy-server"])
+    expect(findScrcpyServer()).toBe("/env/scrcpy-server")
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores SCRCPY_SERVER_PATH pointing at a directory", () => {
+    // `adb push <dir>` would create the remote scrcpy-server.jar as a
+    // directory, so a directory must not resolve as the server.
+    process.env.SCRCPY_SERVER_PATH = "/env/scrcpy-dir"
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found")
+    })
+    mockFilesystem(["/usr/local/share/scrcpy/scrcpy-server"], ["/env/scrcpy-dir"])
+    expect(findScrcpyServer()).toBe("/usr/local/share/scrcpy/scrcpy-server")
+  })
+
+  // Built with path.join so the fixtures use the host separator, matching what
+  // findScrcpyServer derives via path.dirname/path.join on any platform.
+  const binDir = path.join(path.sep, "opt", "scrcpy")
+  const scrcpyBinary = path.join(binDir, "scrcpy")
+  const siblingServer = path.join(binDir, "scrcpy-server")
+
+  it("discovers server next to scrcpy binary on PATH", () => {
+    const lookupCommand = process.platform === "win32" ? "where" : "which"
+    execFileSyncMock.mockReturnValue(`${scrcpyBinary}\n`)
+    mockFilesystem([scrcpyBinary, siblingServer])
+    expect(findScrcpyServer()).toBe(siblingServer)
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      lookupCommand,
+      ["scrcpy"],
+      expect.objectContaining({ encoding: "utf8", timeout: 5000 })
+    )
+  })
+
+  it("looks the binary up with `where` on Windows", () => {
+    // Only the lookup command is platform-branched; path handling comes from
+    // node:path, which stays bound to the host platform even under this stub.
+    const originalPlatform = process.platform
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    })
+    try {
+      // `where` emits CRLF, which the discovery code has to strip before the
+      // path is usable — the original Windows report's root cause elsewhere.
+      execFileSyncMock.mockReturnValue(`${scrcpyBinary}\r\n`)
+      mockFilesystem([scrcpyBinary, siblingServer])
+      expect(findScrcpyServer()).toBe(siblingServer)
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "where",
+        ["scrcpy"],
+        expect.objectContaining({ encoding: "utf8", timeout: 5000 })
+      )
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      })
+    }
+  })
+
+  it("skips PATH entries that are not files", () => {
+    // `where` can report several matches; the first one that is a real file wins.
+    const shadowed = path.join(path.sep, "opt", "shadow", "scrcpy")
+    execFileSyncMock.mockReturnValue(`${shadowed}\n${scrcpyBinary}\n`)
+    mockFilesystem([scrcpyBinary, siblingServer], [shadowed])
+    expect(findScrcpyServer()).toBe(siblingServer)
+  })
+
+  it("falls back to common Unix paths when PATH lookup fails", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found")
+    })
+    mockFilesystem(["/usr/local/share/scrcpy/scrcpy-server"])
+    expect(findScrcpyServer()).toBe("/usr/local/share/scrcpy/scrcpy-server")
+  })
+
+  it("returns null when no server is found", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found")
+    })
+    mockFilesystem([])
+    expect(findScrcpyServer()).toBeNull()
+  })
+})
+
+describe("formatConnectFailure", () => {
+  // The version-mismatch trace scrcpy's server writes to stderr before dying.
+  const versionMismatch =
+    "java.lang.IllegalArgumentException: The server version (4.1) " +
+    "does not match the client (3.3.4)\n"
+
+  it("reports a timeout when the server is still running", () => {
+    const message = formatConnectFailure(27183, 10000, { stderr: "", exit: null })
+    expect(message).toBe(
+      "Failed to connect to scrcpy server on port 27183 within 10000ms"
+    )
+  })
+
+  it("surfaces server stderr so the real cause is visible", () => {
+    const message = formatConnectFailure(27183, 10000, {
+      stderr: versionMismatch,
+      exit: { code: 1, signal: null },
+    })
+    expect(message).toContain("does not match the client")
+    expect(message).toContain("Server stderr:")
+  })
+
+  it("reports the exit rather than the timeout when the server died", () => {
+    const message = formatConnectFailure(27183, 10000, {
+      stderr: "",
+      exit: { code: 1, signal: null },
+    })
+    expect(message).toContain("exited (exit code 1)")
+    expect(message).not.toContain("within 10000ms")
+  })
+
+  it("names the signal when the server was killed", () => {
+    const message = formatConnectFailure(27183, 10000, {
+      stderr: "",
+      exit: { code: null, signal: "SIGKILL" },
+    })
+    expect(message).toContain("exited (signal SIGKILL)")
+  })
+
+  it("omits the stderr section when the server said nothing", () => {
+    const message = formatConnectFailure(27183, 10000, {
+      stderr: "   \n  ",
+      exit: null,
+    })
+    expect(message).not.toContain("Server stderr")
+  })
+})
+
 describe("computeScrcpyVersionInfo", () => {
   const originalEnv = process.env.SCRCPY_SERVER_VERSION
 
   beforeEach(() => {
-    execSyncMock.mockReset()
     delete process.env.SCRCPY_SERVER_VERSION
   })
 
@@ -117,38 +303,53 @@ describe("computeScrcpyVersionInfo", () => {
   it("resolves from the SCRCPY_SERVER_VERSION env var without spawning the binary", () => {
     process.env.SCRCPY_SERVER_VERSION = "4.2"
     expect(computeScrcpyVersionInfo()).toEqual({ version: "4.2", source: "env" })
-    expect(execSyncMock).not.toHaveBeenCalled()
+    expect(execFileSyncMock).not.toHaveBeenCalled()
   })
 
   it("resolves from the scrcpy binary when the env var is unset", () => {
-    execSyncMock.mockReturnValue(
+    execFileSyncMock.mockReturnValue(
       "scrcpy 4.0 <https://github.com/Genymobile/scrcpy>\n"
     )
     expect(computeScrcpyVersionInfo()).toEqual({ version: "4.0", source: "binary" })
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "scrcpy",
+      ["--version"],
+      expect.objectContaining({ encoding: "utf8", timeout: 5000 })
+    )
   })
 
   it("falls back to the default when the binary output does not match", () => {
-    execSyncMock.mockReturnValue("not a scrcpy version line")
+    execFileSyncMock.mockReturnValue("not a scrcpy version line")
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     expect(computeScrcpyVersionInfo()).toEqual({
       version: SCRCPY_SERVER_VERSION,
       source: "default",
     })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("could not detect scrcpy version")
+    )
+    consoleErrorSpy.mockRestore()
   })
 
   it("falls back to the default when the binary is unavailable", () => {
-    execSyncMock.mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       throw new Error("command not found: scrcpy")
     })
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     expect(computeScrcpyVersionInfo()).toEqual({
       version: SCRCPY_SERVER_VERSION,
       source: "default",
     })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("could not detect scrcpy version")
+    )
+    consoleErrorSpy.mockRestore()
   })
 
   it("never reports a source that disagrees with its version", () => {
     // Regression guard: version and source must come from one resolution, so
     // a binary-derived version can never be labelled 'default' and vice versa.
-    execSyncMock.mockReturnValue("scrcpy 3.3.4 <url>\n")
+    execFileSyncMock.mockReturnValue("scrcpy 3.3.4 <url>\n")
     const info = computeScrcpyVersionInfo()
     expect(info.source).toBe("binary")
     expect(info.version).toBe("3.3.4")
@@ -160,8 +361,8 @@ describe("detectScrcpyVersionInfo", () => {
     __resetScrcpyVersionCacheForTests()
     const originalEnv = process.env.SCRCPY_SERVER_VERSION
     delete process.env.SCRCPY_SERVER_VERSION
-    execSyncMock.mockReset()
-    execSyncMock.mockReturnValue("scrcpy 4.0 <https://github.com/Genymobile/scrcpy>\n")
+    execFileSyncMock.mockReset()
+    execFileSyncMock.mockReturnValue("scrcpy 4.0 <https://github.com/Genymobile/scrcpy>\n")
 
     try {
       const first = detectScrcpyVersionInfo()
@@ -169,7 +370,7 @@ describe("detectScrcpyVersionInfo", () => {
       expect(detectScrcpyVersion()).toBe(first.version)
 
       // Cache is now populated; a later resolution failure must not change it.
-      execSyncMock.mockImplementation(() => {
+      execFileSyncMock.mockImplementation(() => {
         throw new Error("binary vanished")
       })
       expect(detectScrcpyVersionInfo()).toEqual(first)


### PR DESCRIPTION
Fixes #50.

## Why `start_session` failed

The client launches the server with a version string that must match the server binary exactly, or the server throws and exits. That string was hardcoded, so any scrcpy install that was not the pinned version died on startup — and because `adb forward` accepts connections whether or not anything is listening behind the tunnel, the failure surfaced only as `Failed to connect to scrcpy server within 10000ms`. The actual cause was in the server's stderr, which nothing ever read.

## Version detection and server discovery

- Detect the version from `scrcpy --version` rather than hardcoding it, memoized so the reported version and the source it is attributed to can never disagree.
- Resolve `scrcpy-server` from the scrcpy binary on `PATH`, since every official distribution ships the two side by side.
- Reject any candidate that is not a regular file. A directory satisfies an existence check, and `adb push <dir>` then creates the remote `scrcpy-server.jar` as a directory — the "Android Directory Conflict" already documented in the README's troubleshooting section.
- Retain the server's stderr (capped at 8 KiB — the adb child lives for the whole session at `log_level=verbose`, and the useful part is the tail) and report it on connection failure, along with whether the process exited rather than timed out. Stop retrying once the adb child is gone, since the server it was running is gone too.
- Drop `SCRCPY_SERVER_VERSION` from the README example, which was handing users a stale pinned version and reintroducing the exact failure documented two sections below it.

The reporter's scenario now fails in about a second with the cause named:

```
The scrcpy server exited (exit code 1) before accepting a connection on port 27183.
Server stderr:
java.lang.IllegalArgumentException: The server version (4.1) does not match the client (3.3.4)
```

## Clipboard ack framing

Unrelated to #50, found while running the integration suite against a device.

The device-message parser only handled `DEVICE_MSG_TYPE_CLIPBOARD`. The `ACK_CLIPBOARD` the server sends after every `SET_CLIPBOARD` with a non-zero sequence fell through to the unknown-type branch, which clears the receive buffer. Harmless when the ack arrives alone — but an ack sharing a TCP read with a clipboard payload discarded that payload, and `clipboard_get` then returned stale text or timed out.

Acks are now skipped by their exact 9-byte length. The framing moved into an exported `consumeDeviceMessages()`, which is what makes it testable at all: the old loop was reachable only by driving a real device through an API-31-gated tool.

## Testing

143 unit tests, up from 127. The new tests were mutation-tested rather than assumed: reverting the ack branch, mis-sizing the ack at 5 bytes, and parsing an ack before all 9 bytes arrive each fail the suite. The connect-failure and Windows `where` paths were checked the same way.

Verified on hardware (Nokia 8 Sirocco, API 29):

- Integration suite passes, 37 tests. The `Unknown device message type: 1` line present before this change is gone after it — same device, same test.
- Live via the MCP tools: four consecutive `clipboard_set` calls with `paste: true`, all landing in order with non-ASCII intact, control stream in sync throughout.

Two limits worth stating. `clipboard_get` is API 31+, so the read half of the clipboard scenario is covered only by unit tests. And the PATH-lookup environment from #50 — scrcpy on the user's shell PATH but absent from a GUI-spawned MCP process's PATH, on Windows — cannot be reproduced here; @leolulu offered to test on their Windows box.

## Follow-up

#51 tracks the remaining gap: server-path discovery and version detection are still two independent ladders that can disagree. Setting `SCRCPY_SERVER_PATH` resolves a server but leaves the version falling back to the default. Split out deliberately, since it changes the user-visible `source` enum and wants testing in an environment none of us can reproduce.
