### PR TITLE
chore: release v0.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "scrcpy-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "homepage": "https://github.com/JuanCF/scrcpy-mcp",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/JuanCF/scrcpy-mcp",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "scrcpy-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: scrcpy-mcp
-version: 0.4.0
+version: 0.4.1
 description: MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices
 startCommand:
   type: stdio


### PR DESCRIPTION
Patch release. Bumps the version to `0.4.1` in `package.json`, `package-lock.json`, `manifest.json`, `server.json` and `smithery.yaml`.

## Changes since v0.4.0

| PR | Change |
|----|--------|
| #46 | docs: MCP badge in README |
| #47 | fix: Windows device detection — strip CR before parsing `adb devices -l` |
| #48 | fix: parse `no permissions` as a full device state |
| #49 | test: integration suite, plus `app_current` regex and `file_list` (`ls -laH`) fixes it depends on |
| #52 | fix: detect the scrcpy server version, stop dropping clipboard acks, surface server stderr on connect failure |

## Why `patch`

No change to the user-facing surface: still 36 tools, no new or renamed tool, no schema changes, and the same two environment variables. The scrcpy-server discovery added in #52 is an extra lookup path that makes `start_session` work where it was broken, not a new capability.

`server.json` is rewritten by the publish workflow anyway; `manifest.json` and `smithery.yaml` are not, so they are bumped here to stay in sync.
