### PR TITLE
chore: align the line-length guidance with what eslint enforces

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,7 +46,12 @@ reviews:
       instructions: |
         Review TypeScript source with these project conventions in mind:
         - ESM imports with `.js` extension for local modules
-        - No semicolons; 2-space indentation; max ~100 chars per line
+        - No semicolons; 2-space indentation
+        - Max ~100 chars per line applies to code only. The `max-len` rule in
+          eslint.config.js sets ignoreStrings, ignoreTemplateLiterals, ignoreUrls
+          and ignoreRegExpLiterals, so long single-line tool `description` and
+          `.describe()` strings are intentional and must not be flagged as
+          length violations. `npm run lint` is the authority on formatting.
         - camelCase for functions/variables, PascalCase for types, snake_case for tool names
         - Prefer `async/await`, early returns, and minimal changes
         - MCP tool registrations must include `inputSchema`, `outputSchema`, `annotations`, and `structuredContent`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ import { execAdbShell, resolveSerial } from "../utils/adb.js";
 ### Formatting
 
 - No semicolons at end of statements
-- 2-space indentation, max line length ~100 characters
+- 2-space indentation, max line length ~100 characters — for code. String literals, template literals, URLs and regexes are exempt (`max-len` in `eslint.config.js` sets `ignoreStrings`, `ignoreTemplateLiterals`, `ignoreUrls`, `ignoreRegExpLiterals`), so the long single-line tool `description` and `.describe()` strings are intentional; don't rewrap them. `npm run lint` is the authority.
 - Trailing commas in multiline arrays/objects
 
 ### Types


### PR DESCRIPTION
Split out of #54, where this surfaced.

## Problem

`AGENTS.md` and the `src/**/*.ts` path instruction in `.coderabbit.yaml` both stated the line-length convention unqualified:

> No semicolons; 2-space indentation; max ~100 chars per line

But `eslint.config.js:39` configures `max-len` with `code: 100` **and** `ignoreStrings`, `ignoreTemplateLiterals`, `ignoreUrls`, `ignoreRegExpLiterals`. Long string literals are therefore exempt by design — 55 lines in `src/` exceed 100 characters (8 in `src/tools/session.ts` alone, the longest at 302), and `npm run lint` passes on all of them. Every MCP tool registration in the repo keeps its `description` and `.describe()` text on one line.

So the written guidance contradicted the linter it was describing. A reviewer reading only the rule flags those strings as violations: CodeRabbit did exactly that on #54, and since `request_changes_workflow: true` is set, a finding that eslint itself does not agree with is enough to hold a PR at `CHANGES_REQUESTED`.

## Change

State the exemption in both places and name `npm run lint` as the authority. No code or lint config changes — the enforced policy is unchanged, only its description.

The `*.md` path instruction is deliberately left alone: "verify docs stay in sync with the source" caught a genuine precedence error in the README on #54 and earns its keep.

## Testing

`npx js-yaml .coderabbit.yaml` parses, and the block scalar renders as one clean bullet in the instruction text. `npm run lint` still passes.
