### PR TITLE
ci: bump android-emulator-runner to v2.38.0 for the Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 30
           arch: x86_64
@@ -154,7 +154,7 @@ jobs:
           test -f "$(dirname "$(which scrcpy)")/scrcpy-server"
 
       - name: Run integration tests
-        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 30
           arch: x86_64


### PR DESCRIPTION
## What

Bumps both `reactivecircus/android-emulator-runner` pins in `ci.yml` from v2.35.0 (`b530d96`) to v2.38.0 (`a421e43`).

## Why

The old pin declares `using: 'node20'` in its `action.yml`. GitHub is [deprecating the Node 20 action runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and currently force-runs such actions on Node 24, which every integration run reports as an annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `reactivecircus/android-emulator-runner@b530d96…`

Today that's only a warning, but the forcing is a migration aid rather than a permanent guarantee — once it's removed the action stops running and both emulator steps break. Upstream fixed this in v2.37.0 (`using: 'node24'`), so the bump is the whole fix.

This is **unrelated to the Node 24 toolchain move in #59**: that changed the runtime the workflow installs for our own code, while this is the runtime GitHub uses to execute the action itself.

## Notes

- Pinned to the commit v2.38.0 resolves to, with the tag as a trailing comment. The tag is annotated, so its ref SHA is a tag object that `uses:` cannot resolve — the dereferenced commit is `a421e43855164a8197daf9d8d40fe71c6996bb0d`, verified to declare `using: 'node24'`.
- Also picked up between v2.35.0 and v2.38.0: build-tools 36.0.0 → 37.0.0, cmdline-tools 12.0, and removal of an unneeded `--abi` option in AVD creation.
- **Watch the AVD cache on first run.** The `--abi` change touches AVD creation, and the cache key (`avd-30-x86_64-<os>-v1`) doesn't include the action version, so the first run restores an AVD built by the old action. Bump the key to `-v2` if it misbehaves.

## Not in scope

Doesn't address the intermittent `MediaCodec` encoder crash on the scrcpy 4.1 leg (`IllegalStateException` in `SurfaceEncoder.encode`), which is a separate emulator flake — confirmed by a clean rerun of the same commit. Also unrelated to the `Please update the emulator to one that supports the feature(s): Vulkan` warning, which appears identically in passing and failing runs.

## Testing

`npm run lint` and `npm test` (161 passed) are clean; no `src/` changes. Real verification is CI on this PR.
