### PR TITLE
chore: release v0.5.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.2",
   "name": "scrcpy-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "homepage": "https://github.com/JuanCF/scrcpy-mcp",
   "icon": "icon.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrcpy-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrcpy-mcp",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "mcpName": "io.github.JuanCF/scrcpy-mcp",
   "description": "MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/JuanCF/scrcpy-mcp",
     "source": "github"
   },
-  "version": "0.4.1",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "scrcpy-mcp",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,5 +1,5 @@
 name: scrcpy-mcp
-version: 0.4.1
+version: 0.5.0
 description: MCP server for Android device control via ADB and scrcpy — gives AI agents vision and control over Android devices
 startCommand:
   type: stdio


### PR DESCRIPTION
Minor release. Bumps the version to `0.5.0` in `package.json`, `package-lock.json`, `manifest.json`, `server.json` and `smithery.yaml`.

## Changes since v0.4.1

| PR | Change |
|----|--------|
| #54 | fix: derive the scrcpy version from the resolved server path |
| #55 | chore: align the line-length guidance with what eslint enforces |
| #57 | fix: resolve scrcpy client/server as a pair to avoid version mismatch |
| #59 | chore: move the toolchain to Node 24 LTS and document the dev workflow |
| #60 | ci: bump android-emulator-runner to v2.38.0 for the Node 24 runtime |

## Why `minor` and not `patch`

Two things changed for anyone already on `0.4.1`:

**The supported runtime moved (#59).** `engines.node` went `>=22.0.0` → `>=24.0.0`, `.nvmrc` went 22 → 24, and the tsup `target` went `node18` → `node24`. The published bundle is now emitted for Node 24, so Node 22 users are not merely warned at install time — they can hit runtime errors. README advertises **Node.js 24+** as a hard requirement. That is not something to ship silently under a patch bump.

**The `version` tool's output schema widened (#54, #57).** `source` went from `"env" | "binary" | "default"` to a five-value enum adding `server-sibling` and `package-manager`. A client validating structured output against the old enum will see values it does not know. The install resolution in `src/utils/scrcpy.ts` also grew a package-manager probe (`dpkg`/`pacman`/`rpm`/`apk`/`brew`), symlink resolution, and client/server pairing with documented precedence — labeled `fix:`, and it does fix a real mismatch bug, but the resolution order is new user-facing behavior.

No `major` because the project is pre-1.0: under 0.x convention breaking changes ride the minor slot, and `1.0.0` would announce an API stability commitment this release is not making.

## Note

`server.json` is rewritten by the publish workflow anyway; `manifest.json` and `smithery.yaml` are not, so they are bumped here to stay in sync.
